### PR TITLE
Update readme: Install from PyPI instead of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `nevergrad` is a Python 3.6+ library. It can be installed with:
 ```
-pip3 install git+https://github.com/facebookresearch/nevergrad@master#egg=nevergrad
+pip install nevergrad
 ```
 Alternatively, you can clone the repository and run `python3 setup.py develop` from inside the repository folder.
 


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fetching a Python package from PyPI is generally faster than installing it from a Github repo: The latter involves a repository clone and typically cannot be cached by pip. Installing a PyPI package also typically means you get a more stable version than what the master branch provides.

<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

Tested on Windows 10, Anaconda Python 3.6 with pip version 18.1

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
