### PR TITLE
Share optimizer style across xp plots

### DIFF
--- a/nevergrad/benchmark/test_plotting.py
+++ b/nevergrad/benchmark/test_plotting.py
@@ -79,3 +79,10 @@ def test_make_style_generator() -> None:
     np.testing.assert_equal(len(set(output)), num)  # no repetition
     repeating = next(gen)
     np.testing.assert_equal(repeating, output[0])
+
+
+def test_name_style() -> None:
+    nstyle = plotting.NameStyle()
+    np.testing.assert_equal(nstyle["blublu"], "-ob")
+    np.testing.assert_equal(nstyle["plop"], "--vg")
+    np.testing.assert_equal(nstyle["blublu"], "-ob")


### PR DESCRIPTION
## Motivation and Context

When plotting, xp plots use line styles defined by the score of the algorithm. However, this makes comparison difficults. It seems better to share each optimizer style across all xp plots.

## How Has This Been Tested

A test has been added + manual experiment.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
