### PR TITLE
Check value type in optimizer.tell

### DIFF
--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -116,6 +116,8 @@ class Optimizer(abc.ABC):  # pylint: disable=too-many-instance-attributes
         value: float
             value of the function
         """
+        if not isinstance(value, (int, float, np.int64, np.float64)):
+            raise TypeError(f'"tell" method only supports float values bug got: {value} (type: {type(value)}.')
         if np.isnan(value) or value == np.inf:
             warnings.warn(f"Updating fitness with {value} value")
         x = tuple(x)

--- a/nevergrad/optimization/test_base.py
+++ b/nevergrad/optimization/test_base.py
@@ -18,9 +18,10 @@ class CounterFunction:
     def __init__(self) -> None:
         self.count = 0
 
-    def __call__(self, value: float) -> float:
+    def __call__(self, value: optimizerlib.base.ArrayLike) -> float:
+        assert len(value) == 1
         self.count += 1
-        return (value - 1)**2
+        return (value[0] - 1)**2
 
 
 class LoggingOptimizer(optimizerlib.base.Optimizer):

--- a/nevergrad/optimization/test_utils.py
+++ b/nevergrad/optimization/test_utils.py
@@ -33,11 +33,11 @@ def test_value_and_point() -> None:
 def test_sequential_executor() -> None:
     func = CounterFunction()
     executor = utils.SequentialExecutor()
-    job1 = executor.submit(func, 3)
+    job1 = executor.submit(func, [3])
     np.testing.assert_equal(job1.done(), True)
     np.testing.assert_equal(job1.result(), 4)
     np.testing.assert_equal(func.count, 1)
-    executor.submit(func, 3)
+    executor.submit(func, [3])
     np.testing.assert_equal(func.count, 2)
 
 


### PR DESCRIPTION
## Motivation and Context

In #26 there is a weird behavior of the `tell` method. An explicit type checking of the value can always be helpful, even though it may not solve #26 anyway.

## How Has This Been Tested

Tests were updated since some tests did not comply with this requirement.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
