### PR TITLE
New `unregister` function

### DIFF
--- a/nevergrad/common/decorators.py
+++ b/nevergrad/common/decorators.py
@@ -31,6 +31,15 @@ class Registry(dict):
             self._information[name] = info
         return obj
 
+    def unregister(self, name:str) -> None:
+        """Remove a previously-registered function or class, e.g. so you can 
+        re-register it in a Jupyter notebook.
+        """
+        if name in self:
+            obj = self[name]
+            if obj in self._registered: self._registered.remove(obj)
+            del self[name]
+
     def register_with_info(self, **info: Any) -> Callable:
         """Decorator for registering a function and information about it
         """


### PR DESCRIPTION
## Motivation and Context

The current decorators allow registering a function/class but don't explicitly provide a way to deregister/unregister that function/class. This is fine when running the code once, but makes developing in Jupyter, where re-running cells is common, harder than it should be.

## How Has This Been Tested

I ran `nosetests nevergrad` and while there were errors, they appeared to be unrelated to this new feature and occurred without it.

I have also used this small feature with my own code without noticeable problem.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.