### PR TITLE
Provide dtype to randint

### DIFF
--- a/docs/adding_an_algorithm.md
+++ b/docs/adding_an_algorithm.md
@@ -65,7 +65,7 @@ For consistency and simplicity's sake, please prefer `numpy`'s random generator 
 Also, you may instanciate a random generator for each optimizer and using it afterwards. This way it makes the optimizer independent of other uses of the default random generator.
 Still, please seed it with the standard numpy random generator so that seeding the standard generator will produce deterministic outputs:
 ```python
-self._rng = np.ranndom.RandomState(np.random.randint(2**32))
+self._rng = np.random.RandomState(np.random.randint(2**32, dtype=np.uint32))
 ```
 
 A unit tests automatically makes sure that all optimizers have repeatable bvehaviors on a simple test case when seeded from outside (see below).

--- a/nevergrad/benchmark/xpbase.py
+++ b/nevergrad/benchmark/xpbase.py
@@ -54,7 +54,7 @@ def create_seed_generator(seed: Optional[int]) -> Iterator[Optional[int]]:
     """
     generator = None if seed is None else np.random.RandomState(seed=seed)
     while True:
-        yield None if generator is None else generator.randint(np.iinfo(np.uint32).max)
+        yield None if generator is None else generator.randint(2**32, dtype=np.uint32)
 
 
 class Experiment:

--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -5,6 +5,7 @@
 
 import abc
 import time
+from numbers import Real
 import warnings
 from typing import Optional, Tuple, Callable, Any, Dict, List, Union
 import numpy as np
@@ -116,7 +117,7 @@ class Optimizer(abc.ABC):  # pylint: disable=too-many-instance-attributes
         value: float
             value of the function
         """
-        if not isinstance(value, (int, float, np.int64, np.float64)):
+        if not isinstance(value, Real):
             raise TypeError(f'"tell" method only supports float values but the passed value was: {value} (type: {type(value)}.')
         if np.isnan(value) or value == np.inf:
             warnings.warn(f"Updating fitness with {value} value")
@@ -129,7 +130,7 @@ class Optimizer(abc.ABC):  # pylint: disable=too-many-instance-attributes
         # this may have to be improved if we want to keep more kinds of best values
         for name in ["optimistic", "pessimistic", "average"]:
             if x == self.current_bests[name].x:   # reboot
-                y: Tuple[float, ...] = min(self.archive, key=lambda x, n=name: self.archive[x].get_estimation(n))  # type: ignore
+                y: Tuple[float, ...] = min(self.archive, key=lambda x, n=name: self.archive[x].get_estimation(n))
                 # rebuild best point may change, and which value did not track the updated value anyway
                 self.current_bests[name] = utils.Point(y, self.archive[y])
             else:

--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -532,7 +532,7 @@ class SPSA(base.Optimizer):
 
     def __init__(self, dimension: int, budget: Optional[int] = None, num_workers: int = 1) -> None:
         super().__init__(dimension, budget=budget, num_workers=num_workers)
-        self._rng = np.random.RandomState(np.random.randint(2**32, dtype=np.int32))
+        self._rng = np.random.RandomState(np.random.randint(2**32, dtype=np.uint32))
         self.init = True
         self.idx = 0
         self.delta = float('nan')

--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -532,7 +532,7 @@ class SPSA(base.Optimizer):
 
     def __init__(self, dimension: int, budget: Optional[int] = None, num_workers: int = 1) -> None:
         super().__init__(dimension, budget=budget, num_workers=num_workers)
-        self._rng = np.random.RandomState(np.random.randint(2**32))
+        self._rng = np.random.RandomState(np.random.randint(2**32, dtype=np.int32))
         self.init = True
         self.idx = 0
         self.delta = float('nan')

--- a/nevergrad/optimization/sequences.py
+++ b/nevergrad/optimization/sequences.py
@@ -86,7 +86,7 @@ class LHSSampler(Sampler):
         self.permutations = np.zeros((dimension, budget), dtype=int)
         for k in range(dimension):
             self.permutations[k] = np.random.permutation(budget)
-        self.seed = np.random.randint(np.iinfo(np.uint32).max)
+        self.seed = np.random.randint(2**32, dtype=np.uint32)
         self.randg = np.random.RandomState(self.seed)
 
     def reinitialize(self) -> None:
@@ -115,7 +115,7 @@ class HaltonPermutationGenerator:
         self.dimension = dimension
         self.scrambling = scrambling
         self.primes = _get_first_primes(dimension).tolist()
-        self.seed = np.random.randint(np.iinfo(np.uint32).max)
+        self.seed = np.random.randint(2**32, dtype=np.uint32)
         self.fulllist = np.arange(self.primes[-1]) if self.primes else []
 
     def get_permutations_generator(self) -> Iterator[ArrayLike]:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,5 @@ setup(
                  'Intended Audience :: Science/Research',
                  'Topic :: Scientific/Engineering',
                  'Programming Language :: Python'],
-    package_data={'': ['LICENSE'],
-                  'nevergrad': ['**/additional/*.py', '**/optimization/*.csv']},
     install_requires=requirements,
 )

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,7 @@ setup(
                  'Intended Audience :: Science/Research',
                  'Topic :: Scientific/Engineering',
                  'Programming Language :: Python'],
+    package_data={'': ['LICENSE'],
+                  'nevergrad': ['**/additional/*.py', '**/optimization/*.csv']},
     install_requires=requirements,
 )


### PR DESCRIPTION
## Motivation and Context

On some installations, tests do not work because of too large numbers for randint #36 
I could not reproduce the error, but investigated the error. It seems that providing dtype could help
(See high bound [here](https://github.com/numpy/numpy/blob/master/numpy/random/mtrand/mtrand.pyx#L977) and how it is defined [here](https://github.com/numpy/numpy/blob/master/numpy/random/mtrand/mtrand.pyx#L590))



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
