### PR TITLE
Make convert_to_arguments deterministic by default

### DIFF
--- a/nevergrad/instrumentation/instantiate.py
+++ b/nevergrad/instrumentation/instantiate.py
@@ -65,7 +65,7 @@ class InstrumentedFile(utils.Instrument):
             text = "\n".join(lines)
         self.text, self.variables = utils.replace_tokens_by_placeholders(text)
 
-    def process(self, data: np.ndarray, deterministic=False) -> str:
+    def process(self, data: np.ndarray, deterministic: bool = False) -> str:
         values = utils.process_instruments(self.variables, data, deterministic=deterministic)
         text = utils.replace_placeholders_by_values(self.text, values)
         return text

--- a/nevergrad/instrumentation/test_variables.py
+++ b/nevergrad/instrumentation/test_variables.py
@@ -42,3 +42,4 @@ def test_hard_discrete() -> None:
 def test_gaussian() -> None:
     token = variables.Gaussian(1, 3)
     np.testing.assert_equal(token.process([.5]), 2.5)
+    np.testing.assert_equal(token.process(token.process_arg(12)), 12)

--- a/nevergrad/instrumentation/utils.py
+++ b/nevergrad/instrumentation/utils.py
@@ -30,7 +30,7 @@ class Instrument:
     def process_arg(self, arg: Any) -> ArrayLike:
         raise NotImplementedError
 
-    def process(self, data: List[float]) -> Any:
+    def process(self, data: List[float], deterministic: bool = False) -> Any:
         raise NotImplementedError
 
     def get_summary(self, data: np.ndarray) -> str:
@@ -55,12 +55,13 @@ def split_data(data: List[float], instruments: Iterable[Instrument]) -> List[Lis
     return splitted_data
 
 
-def process_instruments(instruments: Iterable[Instrument], data: List[float]) -> Tuple[Any, ...]:
+def process_instruments(instruments: Iterable[Instrument], data: List[float],
+                        deterministic: bool = False) -> Tuple[Any, ...]:
     # this function should be removed (but tests of split_data are currently
     # made through this function)
     instruments = list(instruments)
     splitted_data = split_data(data, instruments)
-    return tuple([instrument.process(d) for instrument, d in zip(instruments, splitted_data)])
+    return tuple([instrument.process(d, deterministic=deterministic) for instrument, d in zip(instruments, splitted_data)])
 
 
 def replace_tokens_by_placeholders(text: str) -> Tuple[str, List[Instrument]]:

--- a/nevergrad/instrumentation/variables.py
+++ b/nevergrad/instrumentation/variables.py
@@ -6,10 +6,7 @@
 import re
 from typing import List, Any, Match, Optional
 import numpy as np
-from ..optimization.discretization import (softmax_discretization,
-                                           softmax_probas,
-                                           threshold_discretization,
-                                           inverse_threshold_discretization)
+from ..optimization import discretization
 from ..common.typetools import ArrayLike
 from . import utils
 
@@ -77,27 +74,18 @@ class SoftmaxCategorical(_Variable):
     def dimension(self) -> int:
         return len(self.possibilities)
 
-    def process(self, data: ArrayLike, deterministic: bool = False) -> Any:  # pylint: disable=arguments-differ
+    def process(self, data: ArrayLike, deterministic: bool = False) -> Any:
         assert len(data) == len(self.possibilities)
-        index = int(softmax_discretization(data, len(self.possibilities), deterministic=deterministic)[0])
+        index = int(discretization.softmax_discretization(data, len(self.possibilities), deterministic=deterministic)[0])
         return self.possibilities[index]
 
     def process_arg(self, arg: Any) -> ArrayLike:
         assert arg in self.possibilities, f'{arg} not in allowed values: {self.possibilities}'
-        # TODO: Move to nevergrad.optimization.discretization.inverse_softmax_discretization
-
-        def inverse_softmax_discretization(index: int, arity: int) -> ArrayLike:
-            # p is an arbitrary probability that the provided arg will be sampled with the returned point
-            p = (1 / arity) * 1.5
-            x = np.zeros(arity)
-            x[index] = np.log((p * (arity - 1)) / (1 - p))
-            return x
-
-        return inverse_softmax_discretization(self.possibilities.index(arg), len(self.possibilities))
+        return discretization.inverse_softmax_discretization(self.possibilities.index(arg), len(self.possibilities))
 
     def get_summary(self, data: List[float]) -> str:
         output = self.process(data, deterministic=True)
-        probas = softmax_probas(data)
+        probas = discretization.softmax_probas(data)
         proba_str = ", ".join([f'"{s}": {round(100 * p)}%' for s, p in zip(self.possibilities, probas)])
         return f"Value {output}, from data: {data} yielding probas: {proba_str}"
 
@@ -126,13 +114,13 @@ class OrderedDiscrete(SoftmaxCategorical):
 
     def process(self, data: ArrayLike, deterministic: bool = False) -> Any:  # pylint: disable=arguments-differ, unused-argument
         assert len(data) == 1
-        index = threshold_discretization(data, arity=len(self.possibilities))[0]
+        index = discretization.threshold_discretization(data, arity=len(self.possibilities))[0]
         return self.possibilities[index]
 
     def process_arg(self, arg: Any) -> ArrayLike:
         assert arg in self.possibilities, f'{arg} not in allowed values: {self.possibilities}'
         index = self.possibilities.index(arg)
-        return inverse_threshold_discretization([index], len(self.possibilities))
+        return discretization.inverse_threshold_discretization([index], len(self.possibilities))
 
     def get_summary(self, data: List[float]) -> str:
         output = self.process(data, deterministic=True)
@@ -162,10 +150,13 @@ class Gaussian(_Variable):
     def dimension(self) -> int:
         return 1 if self.shape is None else int(np.prod(self.shape))
 
-    def process(self, data: List[float]) -> Any:
+    def process(self, data: List[float], deterministic: bool = True) -> Any:
         assert len(data) == self.dimension
         x = data[0] if self.shape is None else np.reshape(data, self.shape)
         return self.std * x + self.mean
+
+    def process_arg(self, arg: Any) -> ArrayLike:
+        return [(arg - self.mean) / self.std]
 
     def get_summary(self, data: List[float]) -> str:
         output = self.process(data)
@@ -188,7 +179,7 @@ class _Constant(utils.Instrument):
     def dimension(self) -> int:
         return 0
 
-    def process(self, data: List[float]) -> Any:  # pylint: disable=unused-argument
+    def process(self, data: List[float], deterministic: bool = False) -> Any:  # pylint: disable=unused-argument
         return self._value
 
     def process_arg(self, arg: Any) -> ArrayLike:

--- a/nevergrad/instrumentation/variables.py
+++ b/nevergrad/instrumentation/variables.py
@@ -155,7 +155,7 @@ class Gaussian(_Variable):
         x = data[0] if self.shape is None else np.reshape(data, self.shape)
         return self.std * x + self.mean
 
-    def process_arg(self, arg: Any) -> ArrayLike:
+    def process_arg(self, arg: Any) -> List[float]:
         return [(arg - self.mean) / self.std]
 
     def get_summary(self, data: List[float]) -> str:

--- a/nevergrad/optimization/discretization.py
+++ b/nevergrad/optimization/discretization.py
@@ -85,3 +85,11 @@ def softmax_probas(data: np.ndarray) -> np.ndarray:
     if not sum(data):
         data = np.ones(len(data))
     return data / np.sum(data)
+
+
+def inverse_softmax_discretization(index: int, arity: int) -> ArrayLike:
+    # p is an arbitrary probability that the provided arg will be sampled with the returned point
+    p = (1 / arity) * 1.5
+    x = np.zeros(arity)
+    x[index] = np.log((p * (arity - 1)) / (1 - p))
+    return x

--- a/nevergrad/optimization/test_discretization.py
+++ b/nevergrad/optimization/test_discretization.py
@@ -55,3 +55,8 @@ def test_inverse_threshold_discretization() -> None:
     indexes = np.arange(arity)  # Test all possible indexes
     data = discretization.inverse_threshold_discretization(indexes, arity)
     np.testing.assert_array_equal(discretization.threshold_discretization(data, arity), indexes)
+
+
+def test_inverse_softmax_discretization() -> None:
+    output = discretization.inverse_softmax_discretization(arity=5, index=2)
+    np.testing.assert_array_almost_equal(output, [0, 0, 0.539, 0, 0], decimal=5)


### PR DESCRIPTION
## Motivation and Context

`convert_to_arguments` can be stochastic when using `SoftmaxCategorical`. This PR adds a `deterministic` argument to it, which is True by default, to make it simpler to use.

## How Has This Been Tested

A test has been added

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
