### PR TITLE
62-custom-file-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Some important things to note:
  - using `FolderFunction` argument `clean_copy=True` will copy your folder so that tempering with it during optimization will run different versions of your code.
  - under the hood, with or without `clean_copy=True`, when calling the function, `FolderFunction` will create symlink copy of the initial folder, remove the files that have tokens, and create new ones with appropriate values. Symlinks are used in order to avoid duplicating large projects, but they have some drawbacks, see next point ;)
  - one can add a compilation step to `FolderFunction` (the compilation just has to be included in the script). However, be extra careful that if the initial folder contains some build files, they could be modified by the compilation step, because of the symlinks. Make sure that during compilation, you remove the build symlinks first! **This feature has not been fool proofed yet!!!**
+ - the following external file types are registered by default: `[".c", ".h", ".cpp", ".hpp", ".py", ".m"]`. Custom file types can be registered using `instrumentation.register_file_type` by providing the relevant file suffix as well as the characters that indicate a comment.
 
 
 

--- a/nevergrad/instrumentation/__init__.py
+++ b/nevergrad/instrumentation/__init__.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .folderfunction import FolderFunction
-from .instantiate import InstrumentedFunction
+from .instantiate import InstrumentedFunction, register_file_type
 from . import variables
 from .variables import Instrumentation
 from .utils import TemporaryDirectoryCopy

--- a/nevergrad/instrumentation/folderfunction.py
+++ b/nevergrad/instrumentation/folderfunction.py
@@ -28,8 +28,6 @@ class FolderFunction:  # should derive from BaseFunction?
     clean_copy: bool
         whether to create an initial clean temporary copy of the folder in order to avoid
         versioning problems (instantiations are lightweight symlinks in any case)
-    extension: tuple
-        list of extensions for files to parametrize (files with dftokens)
 
     Returns
     -------
@@ -51,14 +49,11 @@ class FolderFunction:  # should derive from BaseFunction?
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, folder: Union[Path, str], command: List[str], verbose: bool = False, clean_copy: bool = False,
-                 extensions: Optional[List[str]] = None) -> None:
-        if extensions is None:
-            extensions = [".py", "m", ".cpp", ".hpp", ".c", ".h"]
+    def __init__(self, folder: Union[Path, str], command: List[str], verbose: bool = False, clean_copy: bool = False) -> None:
         self.command = command
         self.verbose = verbose
         self.postprocessings = [get_last_line_as_float]
-        self.instrumented_folder = InstrumentedFolder(folder, extensions=extensions, clean_copy=clean_copy)
+        self.instrumented_folder = InstrumentedFolder(folder, clean_copy=clean_copy)
         self.last_full_output: Optional[str] = None
 
     @property

--- a/nevergrad/instrumentation/instantiate.py
+++ b/nevergrad/instrumentation/instantiate.py
@@ -27,7 +27,7 @@ FILE_TYPES = {
 FILE_TYPES[".h"] = FILE_TYPES[".hpp"] = FILE_TYPES[".cpp"] = FILE_TYPES[".c"]
 
 
-def register_file_type(suffix: str, comment_chars: str):
+def register_file_type(suffix: str, comment_chars: str) -> None:
     """Register a new file type to be used for token instrumentation by providing the relevant file suffix as well as
     the characters that indicate a comment."""
     if not suffix.startswith("."):

--- a/nevergrad/instrumentation/test_instantiate.py
+++ b/nevergrad/instrumentation/test_instantiate.py
@@ -45,7 +45,7 @@ class InstantiationTests(TestCase):
     def test_uncomment_line(self, line: str, ext: str, expected: str) -> None:
         self._test_uncomment_line(line, ext, expected)
 
-    @genty.genty_dataset(
+    @genty.genty_dataset(  # type: ignore
         custom=(f"// {LINETOKEN} bidule", ".custom", "//", "bidule"),
         wrong_comment_chars=(f"// {LINETOKEN} bidule", ".custom", "#", RuntimeError),
     )

--- a/nevergrad/instrumentation/test_instantiate.py
+++ b/nevergrad/instrumentation/test_instantiate.py
@@ -52,7 +52,7 @@ class InstantiationTests(TestCase):
     def test_uncomment_line_custom_file_type(self, line: str, ext: str, comment: str, expected: str) -> None:
         instantiate.register_file_type(ext, comment)
         self._test_uncomment_line(line, ext, expected)
-        del instantiate.FILE_TYPES[ext]
+        del instantiate.COMMENT_CHARS[ext]
 
     @genty.genty_dataset(  # type: ignore
         with_clean_copy=(True,),


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Using custom file types for token instrumentation raised an exception as detailed in #62 . Using custom file types (extensions) was therefore not possible.

## How Has This Been Tested (if it applies)

```
nosetests nevergrad
nosetests nevergrad.instrumentation.test_instantiate
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
