### PR TITLE
Fixed bayes-opt version + recaster provide

### DIFF
--- a/nevergrad/optimization/recaster.py
+++ b/nevergrad/optimization/recaster.py
@@ -228,9 +228,7 @@ class RecastOptimizer(base.Optimizer):
         """Returns the underlying optimizer output if provided (ie if the optimizer did finish)
         else the best pessimistic point.
         """
-        self._check_error()
         assert self._messaging_thread is not None, 'Optimization was not even started'
-        self._messaging_thread.stop()
         if self._messaging_thread.output is not None:
             return self._messaging_thread.output
         return self.current_bests["pessimistic"].x

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.15.0
 pandas>=0.23.4
 cma>=2.6.0
-bayesian-optimization>=0.6.0
+bayesian-optimization==0.6.0
 matplotlib>=2.2.3
 nose>=1.3.7
 genty>=1.3.2


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

bayes-optimization has a new API. As a quickfix for #70 , this PR fixes its version to 0.6.0 (old one) before we have time to update it.

Also, calling provide_recommendation on unfinished recast algorithms will not raise execption anymore.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
