### PR TITLE
Make Experiment and BenchmarkChunk stateful

### DIFF
--- a/nevergrad/benchmark/core.py
+++ b/nevergrad/benchmark/core.py
@@ -176,6 +176,7 @@ class BenchmarkChunk:
                     warnings.warn(f"Could not resume unfinished xp: {self._current_experiment}")
                 else:
                     print("Resuming existing experiment.", flush=True)
+                    xp = self._current_experiment  # replace by this one which is already started
             self._current_experiment = xp
             xp.run()
             summary = xp.get_description()

--- a/nevergrad/benchmark/core.py
+++ b/nevergrad/benchmark/core.py
@@ -178,7 +178,9 @@ class BenchmarkChunk:
                     warnings.warn(f"Could not resume unfinished xp: {self._current_experiment}")
                     self._current_experiment = xp
                 else:
-                    print("Resuming existing experiment.", flush=True)
+                    opt = self._current_experiment._optimizer
+                    if opt is not None:
+                        print(f"Resuming existing experiment from iteration {opt.num_ask}.", flush=True)
             self._current_experiment.run()
             summary = self._current_experiment.get_description()
             if process_function is not None:

--- a/nevergrad/benchmark/core.py
+++ b/nevergrad/benchmark/core.py
@@ -171,7 +171,7 @@ class BenchmarkChunk:
                 continue  # already computed
             indstr = f'{index} ({local_ind + 1}/{len(self)} of worker)'
             print(f"Starting {indstr}: {xp}", flush=True)
-            if self._current_experiment is not None:
+            if self._current_experiment is None:
                 self._current_experiment = xp
             else:  # computation was started but interrupted (eg: KeyboardInterrupt)
                 if xp != self._current_experiment:

--- a/nevergrad/benchmark/core.py
+++ b/nevergrad/benchmark/core.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import datetime
+import warnings
 import itertools
 import importlib.util
 from pathlib import Path
@@ -94,6 +95,7 @@ class BenchmarkChunk:
         plan holds 10k experiment, we can select the first cap_index=100 for instance)
     """
 
+    # pylint: disable=too-many-instance-attributes
     def __init__(self, name: str, repetitions: int = 1, seed: Optional[int] = None, cap_index: Optional[int] = None) -> None:
         self.name = name
         self.seed = seed
@@ -101,6 +103,7 @@ class BenchmarkChunk:
         self._moduler: Optional[Moduler] = None
         self.repetitions = repetitions
         self.summaries: List[Dict[str, Any]] = []
+        self._current_experiment: Optional[Experiment] = None  # for stopping and resuming
         self._id = (datetime.datetime.now().strftime("%y-%m-%d_%H%M") + "_" +
                     "".join(np.random.choice([x for x in "abcdefghijklmnopqrstuvwxyz"], 4)))
 
@@ -124,6 +127,7 @@ class BenchmarkChunk:
         # check experiments.py to see seedable xp
         generators = [maker() if seed is None else maker(seed=seed) for seed in seeds]
         generators = [itertools.islice(g, 0, self.cap_index) for g in generators]
+        # pylint: disable=not-callable
         enumerated_selection = ((k, s) for (k, s) in enumerate(itertools.chain.from_iterable(generators)) if self.moduler(k))
         return enumerated_selection
 
@@ -167,11 +171,18 @@ class BenchmarkChunk:
                 continue  # already computed
             indstr = f'{index} ({local_ind + 1}/{len(self)} of worker)'
             print(f"Starting {indstr}: {xp}", flush=True)
+            if self._current_experiment is not None:
+                if xp != self._current_experiment:
+                    warnings.warn(f"Could not resume unfinished xp: {self._current_experiment}")
+                else:
+                    print("Resuming existing experiment.", flush=True)
+            self._current_experiment = xp
             xp.run()
             summary = xp.get_description()
             if process_function is not None:
                 process_function(self, xp)
             self.summaries.append(summary)
+            self._current_experiment = None
             print(f"Finished {indstr}", flush=True)
         return tools.Selector(data=self.summaries)
 

--- a/nevergrad/benchmark/core.py
+++ b/nevergrad/benchmark/core.py
@@ -172,16 +172,17 @@ class BenchmarkChunk:
             indstr = f'{index} ({local_ind + 1}/{len(self)} of worker)'
             print(f"Starting {indstr}: {xp}", flush=True)
             if self._current_experiment is not None:
+                self._current_experiment = xp
+            else:  # computation was started but interrupted (eg: KeyboardInterrupt)
                 if xp != self._current_experiment:
                     warnings.warn(f"Could not resume unfinished xp: {self._current_experiment}")
+                    self._current_experiment = xp
                 else:
                     print("Resuming existing experiment.", flush=True)
-                    xp = self._current_experiment  # replace by this one which is already started
-            self._current_experiment = xp
-            xp.run()
-            summary = xp.get_description()
+            self._current_experiment.run()
+            summary = self._current_experiment.get_description()
             if process_function is not None:
-                process_function(self, xp)
+                process_function(self, self._current_experiment)
             self.summaries.append(summary)
             self._current_experiment = None
             print(f"Finished {indstr}", flush=True)

--- a/nevergrad/benchmark/test_xpbase.py
+++ b/nevergrad/benchmark/test_xpbase.py
@@ -52,6 +52,7 @@ def test_run_with_error() -> None:
             summary = xp.run()
     testing.assert_set_equal(summary.keys(), DESCRIPTION_KEYS)
     np.testing.assert_equal(summary["error"], "ValueError")
+    assert xp._optimizer is not None
     np.testing.assert_equal(xp._optimizer.num_tell, 0)  # make sure optimizer is kept in case we need to restart (eg.: KeyboardInterrupt)
     assert not np.isnan(summary["loss"]), "Loss should be recorded with the current recommendation"
 

--- a/nevergrad/benchmark/test_xpbase.py
+++ b/nevergrad/benchmark/test_xpbase.py
@@ -52,6 +52,7 @@ def test_run_with_error() -> None:
             summary = xp.run()
     testing.assert_set_equal(summary.keys(), DESCRIPTION_KEYS)
     np.testing.assert_equal(summary["error"], "ValueError")
+    np.testing.assert_equal(xp._optimizer.num_tell, 0)  # make sure optimizer is kept in case we need to restart (eg.: KeyboardInterrupt)
     assert not np.isnan(summary["loss"]), "Loss should be recorded with the current recommendation"
 
 

--- a/nevergrad/benchmark/xpbase.py
+++ b/nevergrad/benchmark/xpbase.py
@@ -213,14 +213,12 @@ class Experiment:
             # ("production" steady state is a not strictly steady state + does not handle mocked delays)
             executor: Optional[execution.MockedSteadyExecutor] = None if self.optimsettings.batch_mode else execution.MockedSteadyExecutor()
             try:
-                self.recommendation = self._optimizer.optimize(counter, batch_mode=self.optimsettings.batch_mode,
-                                                               executor=executor, verbosity=1)
+                self.recommendation = self._optimizer.optimize(counter, batch_mode=self.optimsettings.batch_mode, executor=executor)
             except Exception as e:  # pylint: disable=broad-except
                 self.recommendation = self._optimizer.provide_recommendation()  # get the recommendation anyway
                 self._log_results(t0, counter.num_calls)
                 raise e
         self._log_results(t0, counter.num_calls)
-        self._optimizer = None
 
     def get_description(self) -> Dict[str, Union[str, float, bool]]:
         """Return the description of the experiment, as a dict.

--- a/nevergrad/benchmark/xpbase.py
+++ b/nevergrad/benchmark/xpbase.py
@@ -196,10 +196,11 @@ class Experiment:
             This is only for easier debugging.
         """
         if self.seed is not None:
+            # Note: when resuming a job (if optimizer is not None), seeding is pointless (reproducibility is lost)
             np.random.seed(self.seed)
             random.seed(self.seed)
         # optimizer instantiation can be slow and is done only here to make xp iterators very fast
-        if self._optimizer is None:  # Note: when resuming a job (optimizer is not None), seeding is pointless (reproducibility is lost)
+        if self._optimizer is None:  # if optimizer is not None, we are resuming a job (after KeyboardInterrupt for instance)
             self._optimizer = self.optimsettings.instanciate(dimension=self.function.dimension)
         if callbacks is not None:
             for name, func in callbacks.items():


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Since optimizer is now stateful and can be stopped and resumed anytime, Experiment and BenchmarkChunk can be stateful too and can then resume one experiment of a chunk in the middle of an optimization.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
