### PR TITLE
Ignore pseudotime for plotting

### DIFF
--- a/nevergrad/benchmark/plotting.py
+++ b/nevergrad/benchmark/plotting.py
@@ -119,10 +119,10 @@ def create_plots(df: pd.DataFrame, output_folder: PathLike, max_combsize: int = 
     output_folder = Path(output_folder)
     os.makedirs(output_folder, exist_ok=True)
     # check which descriptors do vary
-    descriptors = sorted(set(df.columns) - (required | {"seed"}))  # all other columns are descriptors
+    descriptors = sorted(set(df.columns) - (required | {"seed", "pseudotime"}))  # all other columns are descriptors
     to_drop = [x for x in descriptors if len(df.unique(x)) == 1]
     df = tools.Selector(df.loc[:, [x for x in df.columns if x not in to_drop]])
-    descriptors = sorted(set(df.columns) - (required | {"seed"}))  # now those should be actual interesting descriptors
+    descriptors = sorted(set(df.columns) - (required | {"seed", "pseudotime"}))  # now those should be actual interesting descriptors
     print(f"Descriptors: {descriptors}")
     #
     # fight plot


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

#117 made plotting go completely wrong because pseudo time was considered as a descriptor.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

Manually run plotting.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
