### PR TITLE
Avoid casting to tuple in base Optimizer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: autopep8-wrapper
         args: ['-i', '--max-line-length=140']
 -   repo: https://github.com/pre-commit/mirrors-pylint
-    sha: v2.1.1
+    sha: v2.3.0
     hooks:
     -   id: pylint
         exclude: ^scripts/

--- a/nevergrad/optimization/differentialevolution.py
+++ b/nevergrad/optimization/differentialevolution.py
@@ -49,19 +49,20 @@ class _DE(base.Optimizer):
         return self._llambda
 
     def match_population_size_to_lambda(self) -> None:
-        if len(self.population) < self.llambda:
-            self.candidates += [None] * (self.llambda - len(self.population))
-            self.population_fitnesses += [None] * (self.llambda - len(self.population))
-            self.population += [None] * (self.llambda - len(self.population))
+        current_pop = len(self.population)
+        if current_pop < self.llambda:
+            self.candidates.extend([None] * (self.llambda - current_pop))
+            self.population_fitnesses.extend([None] * (self.llambda - current_pop))
+            self.population.extend([None] * (self.llambda - current_pop))
 
-    def _internal_provide_recommendation(self) -> Tuple[float, ...]:  # This is NOT the naive version. We deal with noise.
+    def _internal_provide_recommendation(self) -> np.ndarray:  # This is NOT the naive version. We deal with noise.
         if self._parameters.recommendation != "noisy":
             return self.current_bests[self._parameters.recommendation].x
         med_fitness = np.median([f for f in self.population_fitnesses if f is not None])
         good_guys = [p for p, f in zip(self.population, self.population_fitnesses) if f is not None and f < med_fitness]
         if not good_guys:
             return self.current_bests["pessimistic"].x
-        return sum([np.array(g) for g in good_guys]) / len(good_guys)  # type: ignore
+        return sum([np.array(g) for g in good_guys]) / len(good_guys)
 
     def _internal_ask(self) -> Tuple[float, ...]:
         init = self._parameters.initialization

--- a/nevergrad/optimization/recaster.py
+++ b/nevergrad/optimization/recaster.py
@@ -208,7 +208,7 @@ class RecastOptimizer(base.Optimizer):
     def _check_error(self) -> None:
         if self._messaging_thread is not None:
             if self._messaging_thread.error is not None:
-                raise RuntimeError("Recast optimizer raised an error") from self._messaging_thread.error
+                raise RuntimeError(f"Recast optimizer raised an error:\n{self._messaging_thread.error}") from self._messaging_thread.error
 
     def _internal_tell(self, x: base.ArrayLike, value: float) -> None:
         """Returns value for a point which was "asked"

--- a/nevergrad/optimization/recastlib.py
+++ b/nevergrad/optimization/recastlib.py
@@ -38,7 +38,7 @@ class _ScipyMinimizeBase(recaster.SequentialRecastOptimizer):
         remaining = budget - self._num_ask
         while remaining > 0:  # try to restart if budget is not elapsed
             options: Dict[str, int] = {} if self.budget is None else {"maxiter": remaining}
-            res = scipyoptimize.minimize(objective_function, best_x if not self._parameters.random_restart else
+            res = scipyoptimize.minimize(objective_function, 0. + best_x if not self._parameters.random_restart else
                                          np.random.normal(0., 1., self.dimension), method=self._parameters.method, options=options, tol=0)
             if res.fun < best_res:
                 best_res = res.fun

--- a/nevergrad/optimization/recastlib.py
+++ b/nevergrad/optimization/recastlib.py
@@ -34,11 +34,11 @@ class _ScipyMinimizeBase(recaster.SequentialRecastOptimizer):
         best_res = np.inf
         best_x = np.zeros(self.dimension)
         if self.initial_guess is not None:
-            best_x = self.initial_guess
+            best_x = np.array(self.initial_guess, copy=True)  # copy, just to make sure it is not modified
         remaining = budget - self._num_ask
         while remaining > 0:  # try to restart if budget is not elapsed
             options: Dict[str, int] = {} if self.budget is None else {"maxiter": remaining}
-            res = scipyoptimize.minimize(objective_function, 0. + best_x if not self._parameters.random_restart else
+            res = scipyoptimize.minimize(objective_function, best_x if not self._parameters.random_restart else
                                          np.random.normal(0., 1., self.dimension), method=self._parameters.method, options=options, tol=0)
             if res.fun < best_res:
                 best_res = res.fun

--- a/nevergrad/optimization/utils.py
+++ b/nevergrad/optimization/utils.py
@@ -88,11 +88,13 @@ class Point(Value):
         the value estimation instance
     """
 
-    def __init__(self, x: Tuple[float, ...], value: Value) -> None:
+    def __init__(self, x: np.ndarray, value: Value) -> None:
         assert isinstance(value, Value)
         super().__init__(value.mean)
         self.__dict__.update(value.__dict__)
-        self.x = x
+        assert not isinstance(x, (str, bytes))
+        self.x = np.array(x, copy=True)  # copy to avoid interfering with algorithms
+        self.x.flags.writeable = False  # make sure it is not modified!
 
     def __repr__(self) -> str:
         return "Point<x: {}, mean: {}, count: {}>".format(self.x, self.mean, self.count)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Following #129 optimizer base does not need to cast to tuple.

Also:
- copy array in Point class, to avoid interfering with underlying algorithms (got errors with scipy optimizers)
- update population matching to use `extend` because of weird pylint/astroid behavior.
- updated pylint

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
