### PR TITLE
Add a parameter to plotting for pseudotime plots

### DIFF
--- a/nevergrad/benchmark/test_plotting.py
+++ b/nevergrad/benchmark/test_plotting.py
@@ -53,7 +53,7 @@ def test_make_sorted_winrates() -> None:
 def test_create_plots_from_csv() -> None:
     df = pd.read_csv(Path(__file__).parent / "sphere_perf_example.csv")
     with patch('matplotlib.pyplot.savefig'):
-        plotting.create_plots(df, "", max_combsize=2)
+        plotting.create_plots(df, "", max_combsize=1)
 
 
 def test_remove_errors() -> None:

--- a/nevergrad/benchmark/test_plotting.py
+++ b/nevergrad/benchmark/test_plotting.py
@@ -53,7 +53,7 @@ def test_make_sorted_winrates() -> None:
 def test_create_plots_from_csv() -> None:
     df = pd.read_csv(Path(__file__).parent / "sphere_perf_example.csv")
     with patch('matplotlib.pyplot.Figure.savefig'):
-        with patch('matplotlib.pyplot.Figure.tight_layout'):
+        with patch('matplotlib.pyplot.Figure.tight_layout'):  # avoid warning message
             plotting.create_plots(df, "", max_combsize=1)
 
 

--- a/nevergrad/benchmark/test_plotting.py
+++ b/nevergrad/benchmark/test_plotting.py
@@ -52,7 +52,7 @@ def test_make_sorted_winrates() -> None:
 
 def test_create_plots_from_csv() -> None:
     df = pd.read_csv(Path(__file__).parent / "sphere_perf_example.csv")
-    with patch('matplotlib.pyplot.savefig'):
+    with patch('matplotlib.pyplot.Figure.savefig'):
         plotting.create_plots(df, "", max_combsize=1)
 
 

--- a/nevergrad/benchmark/test_plotting.py
+++ b/nevergrad/benchmark/test_plotting.py
@@ -53,7 +53,8 @@ def test_make_sorted_winrates() -> None:
 def test_create_plots_from_csv() -> None:
     df = pd.read_csv(Path(__file__).parent / "sphere_perf_example.csv")
     with patch('matplotlib.pyplot.Figure.savefig'):
-        plotting.create_plots(df, "", max_combsize=1)
+        with patch('matplotlib.pyplot.Figure.tight_layout'):
+            plotting.create_plots(df, "", max_combsize=1)
 
 
 def test_remove_errors() -> None:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Following #117, this adds a way to plot according to pseudotime instead of budget.
This is done through a `--pseudotime` flag in the plotting commandline.
Eg.: `python -m nevergrad.benchmark.plotting mycsv.csv --pseudotime`

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
