### PR TITLE
Stop checking calls to fake function in BO

### DIFF
--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -1024,8 +1024,12 @@ class _BO(base.Optimizer):
         return candidate
 
     def _internal_tell_candidate(self, candidate: base.Candidate, value: float) -> None:
-        y = np.array(candidate._meta["x_probe"], copy=False)
+        if "x_probe" in candidate._meta:
+            y = self._transform.forward(np.array(candidate.data, copy=False))  # tell not asked
+        else:
+            y = self._transform.forward(np.array(candidate.data, copy=False))  # tell not asked
         self._fake_function.register(y, -value)  # minimizing
+
         self.bo.probe(y, lazy=False)
         # for some unknown reasons, BO wants to evaluate twice the same point,
         # but since it keeps a cache of the values, the registered value is not used


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

#179 
For some unknown reason, BO package seems to ask twice for a point, but kept a memory of the value so does not call the "fake" function, which triggered an error. This test is therefore removed.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
