### PR TITLE
Added dump and load methods for optimizers

### DIFF
--- a/nevergrad/optimization/differentialevolution.py
+++ b/nevergrad/optimization/differentialevolution.py
@@ -35,7 +35,7 @@ class _DE(base.Optimizer):
         super().__init__(instrumentation, budget=budget, num_workers=num_workers)
         self._parameters = DifferentialEvolution()
         self._llambda: Optional[int] = None
-        self.population = base.utils.Population[DEParticle]([])
+        self.population: base.utils.Population[DEParticle] = base.utils.Population([])
         self.sampler: Optional[sequences.Sampler] = None
         self.NF = False  # This is not a noise-free variant of DE.
         self._replaced: Set[bytes] = set()

--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -594,7 +594,7 @@ class PSO(base.Optimizer):
     def __init__(self, instrumentation: Union[int, Instrumentation], budget: Optional[int] = None, num_workers: int = 1) -> None:
         super().__init__(instrumentation, budget=budget, num_workers=num_workers)
         self.llambda = max(40, num_workers)
-        self.population = utils.Population[PSOParticle]([])
+        self.population: utils.Population[PSOParticle] = utils.Population([])
         self.best_position = np.zeros(self.dimension, dtype=float)  # TODO: use current best instead?
         self.best_fitness = float("inf")
         self.omega = 0.5 / np.log(2.)

--- a/nevergrad/optimization/test_optimizerlib.py
+++ b/nevergrad/optimization/test_optimizerlib.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import random
+import tempfile
 import warnings
 from pathlib import Path
 from functools import partial
@@ -234,3 +235,15 @@ def test_optimization_doc_instrumentation_example() -> None:
 def test_optimization_discrete_with_one_sample() -> None:
     optimizer = optimizerlib.PortfolioDiscreteOnePlusOne(instrumentation=1, budget=10)
     optimizer.optimize(_square)
+
+
+@pytest.mark.parametrize("name", ["TBPSA", "PSO", "TwoPointsDE"])  # type: ignore
+def test_population_pickle(name: str):  # this test is added because some generic class (like Population) can fail to be pickled
+    # example of work around:
+    # "self.population = base.utils.Population[DEParticle]([])"
+    # becomes:
+    # "self.population: base.utils.Population[DEParticle] = base.utils.Population([])""
+    optim = registry[name](instrumentation=12, budget=100, num_workers=2)
+    with tempfile.TemporaryDirectory() as folder:
+        filepath = Path(folder) / "dump_test.pkl"
+        optim.dump(filepath)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Simplify dumping and loading of optimizers as this use case comes back quite often (example: #49). The type hints were however messing up with pickle so some debugging was also necessary

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

Test have been added for pickling of sensitive optimizers (population based optimizers, which have a type hinted generic population which could mess up with the pickling).

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
