### PR TITLE
adding multiobjective optimization in nevergrad

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,17 @@ The [optimization documentation](docs/optimization.md) contains more information
 Let us minimize x1 and x2 (two objective functions) assuming that values above 2.5 are of no interest.
 ```python
 import nevergrad as ng
+import numpy as np
 
-# Let us work in dimension 7.
-# The instrumentation parameter can be an Instrumentation (describing variables and their types) or just the dimension in the
-# continuous case; it is not mandatory if functions provided as arguments are equipped with an instrumentation.
-f = ng.optimizers.multiobjective_minimization([lambda x: x[0], lambda x: x[1]], bad_values=[2.5, 2.5], 7)
-optimizer = ng.optimizers.CMA(instrumentation=f.instrumentation, budget=100)  # 2 is the dimension, 100 is the budget.
+f = ng.optimizers.multiobjective_minimization([lambda x: x[0], lambda x: x[1]], bad_values=[2.5, 2.5])
+
+# Let us work in dimension 3.
+# Let us check that it works.
+print(f(np.array([1,2,3])))
+
+# The parameter ``instrumentation`` can be replaced by a more sophisticated instrumentation (docs/instrumentation.md).
+# We here just use the dimension as we assume simple continuous rescaled variables (mean 0, std 1).
+optimizer = ng.optimizers.CMA(instrumentation=3, budget=100)  # 2 is the dimension, 100 is the budget.
 recommendation = optimizer.optimize(f)
 
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ Let us minimize x1 and x2 (two objective functions) assuming that values above 2
 ```python
 import nevergrad as ng
 
-f = ng.functions.multiobjective_minimization([lambda x: x[0], lambda x: x[1]], bad_values=[2.5, 2.5])
+# Let us work in dimension 7.
+# The instrumentation parameter can be an Instrumentation (describing variables and their types) or just the dimension in the
+# continuous case; it is not mandatory if functions provided as arguments are equipped with an instrumentation.
+f = ng.optimizers.multiobjective_minimization([lambda x: x[0], lambda x: x[1]], bad_values=[2.5, 2.5], 7)
 optimizer = ng.optimizers.CMA(instrumentation=f.instrumentation, budget=100)  # 2 is the dimension, 100 is the budget.
 recommendation = optimizer.optimize(f)
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ print(list(sorted(ng.optimizers.registry.keys())))
 
 The [optimization documentation](docs/optimization.md) contains more information on how to use several workers, take full control of the optimization through the `ask` and `tell` interface and some pieces of advice on how to choose the proper optimizer for your problem.
 
+## Multiobjective minimization with Nevergrad
+
+```python
+import nevergrad as ng
+
+f = ng.functions.multiobjective_minimization([lambda x: x[0], lambda x: x[1]])
+optimizer = ng.optimizers.CMA(instrumentation=2, budget=100)  # 2 is the dimension, 100 is the budget.
+recommendation = optimizer.optimize(square)
+
+
+# The function embeds its Pareto-front:
+print("My Pareto front:", f())
+```
+
 ## Citing
 
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ The [optimization documentation](docs/optimization.md) contains more information
 
 ## Multiobjective minimization with Nevergrad
 
+Let us minimize x1 and x2 (two objective functions) assuming that values above 2.5 are of no interest.
 ```python
 import nevergrad as ng
 
-f = ng.functions.multiobjective_minimization([lambda x: x[0], lambda x: x[1]])
+f = ng.functions.multiobjective_minimization([lambda x: x[0], lambda x: x[1]], bad_values=[2.5, 2.5])
 optimizer = ng.optimizers.CMA(instrumentation=2, budget=100)  # 2 is the dimension, 100 is the budget.
 recommendation = optimizer.optimize(f)
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ import nevergrad as ng
 
 f = ng.functions.multiobjective_minimization([lambda x: x[0], lambda x: x[1]])
 optimizer = ng.optimizers.CMA(instrumentation=2, budget=100)  # 2 is the dimension, 100 is the budget.
-recommendation = optimizer.optimize(square)
+recommendation = optimizer.optimize(f)
 
 
 # The function embeds its Pareto-front:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Let us minimize x1 and x2 (two objective functions) assuming that values above 2
 import nevergrad as ng
 
 f = ng.functions.multiobjective_minimization([lambda x: x[0], lambda x: x[1]], bad_values=[2.5, 2.5])
-optimizer = ng.optimizers.CMA(instrumentation=2, budget=100)  # 2 is the dimension, 100 is the budget.
+optimizer = ng.optimizers.CMA(instrumentation=f.instrumentation, budget=100)  # 2 is the dimension, 100 is the budget.
 recommendation = optimizer.optimize(f)
 
 

--- a/nevergrad/benchmark/experiments.py
+++ b/nevergrad/benchmark/experiments.py
@@ -31,7 +31,7 @@ def moo(seed: Optional[int] = None) -> Iterator[Experiment]:
     functions = [
         multiobjective_minimization([ArtificialFunction(name1, block_dimension=7),
                                      ArtificialFunction(name2, block_dimension=7),
-                                     bad_values=[10000.]*2])
+                                     bad_values=[10000.]*2)
         for name1 in ["sphere", "cigar"]
         for name2 in ["sphere", "cigar", "hm"]
     ]

--- a/nevergrad/benchmark/experiments.py
+++ b/nevergrad/benchmark/experiments.py
@@ -21,6 +21,29 @@ from . import frozenexperiments  # noqa # pylint: disable=unused-import
 # for black (since lists are way too long...):
 # fmt: off
 
+
+@registry.register
+def moo(seed: Optional[int] = None) -> Iterator[Experiment]:
+    # prepare list of parameters to sweep for independent variables
+    seedg = create_seed_generator(seed)
+    optims = ["NaiveTBPSA", "PSO", "DE", "LhsDE", "RandomSearch"]
+    functions = [
+        multiobjective_minimization([ArtificialFunction(name1), ArtificialFunction(name2)])
+        for name1 in ["sphere", "cigar"]
+        for name2 in ["sphere", "cigar", "hm"]
+    ]
+    functions += [
+        multiobjective_minimization([ArtificialFunction(name1), ArtificialFunction(name2), ArtificialFunction(name3)])
+        for name1 in ["sphere", "cigar"]
+        for name2 in ["sphere", "ellipsoid"]
+        for name3 in ["sphere", "cigar", "hm"]
+    ]
+    # functions are not initialized and duplicated at yield time, they will be initialized in the experiment (no need to seed here)
+    for func in functions:
+        for optim in optims:
+            for budget in list(range(100, 2901, 400)):
+                yield Experiment(func, optim, budget=budget, num_workers=1, seed=next(seedg))
+
 # Discrete functions on {0,1}^d.
 @registry.register
 def discrete2(seed: Optional[int] = None) -> Iterator[Experiment]:

--- a/nevergrad/benchmark/experiments.py
+++ b/nevergrad/benchmark/experiments.py
@@ -30,7 +30,7 @@ def moo(seed: Optional[int] = None) -> Iterator[Experiment]:
     optims = ["NaiveTBPSA", "PSO", "DE", "LhsDE", "RandomSearch"]
     functions = [
         multiobjective_minimization([ArtificialFunction(name1, block_dimension=7),
-                                     ArtificialFunction(name2, block_dimension=7),
+                                     ArtificialFunction(name2, block_dimension=7)],
                                      bad_values=[10000.]*2)
         for name1 in ["sphere", "cigar"]
         for name2 in ["sphere", "cigar", "hm"]

--- a/nevergrad/benchmark/experiments.py
+++ b/nevergrad/benchmark/experiments.py
@@ -29,12 +29,15 @@ def moo(seed: Optional[int] = None) -> Iterator[Experiment]:
     seedg = create_seed_generator(seed)
     optims = ["NaiveTBPSA", "PSO", "DE", "LhsDE", "RandomSearch"]
     functions = [
-        multiobjective_minimization([ArtificialFunction(name1), ArtificialFunction(name2)])
+        multiobjective_minimization([ArtificialFunction(name1, block_dimension=7),
+                                     ArtificialFunction(name2, block_dimension=7)])
         for name1 in ["sphere", "cigar"]
         for name2 in ["sphere", "cigar", "hm"]
     ]
     functions += [
-        multiobjective_minimization([ArtificialFunction(name1), ArtificialFunction(name2), ArtificialFunction(name3)])
+        multiobjective_minimization([ArtificialFunction(name1, block_dimension=6), 
+                                     ArtificialFunction(name2, block_dimension=6), 
+                                     ArtificialFunction(name3, block_dimension=6)])
         for name1 in ["sphere", "cigar"]
         for name2 in ["sphere", "ellipsoid"]
         for name3 in ["sphere", "cigar", "hm"]

--- a/nevergrad/benchmark/experiments.py
+++ b/nevergrad/benchmark/experiments.py
@@ -30,14 +30,16 @@ def moo(seed: Optional[int] = None) -> Iterator[Experiment]:
     optims = ["NaiveTBPSA", "PSO", "DE", "LhsDE", "RandomSearch"]
     functions = [
         multiobjective_minimization([ArtificialFunction(name1, block_dimension=7),
-                                     ArtificialFunction(name2, block_dimension=7)])
+                                     ArtificialFunction(name2, block_dimension=7),
+                                     bad_values=[10000.]*2])
         for name1 in ["sphere", "cigar"]
         for name2 in ["sphere", "cigar", "hm"]
     ]
     functions += [
         multiobjective_minimization([ArtificialFunction(name1, block_dimension=6), 
                                      ArtificialFunction(name2, block_dimension=6), 
-                                     ArtificialFunction(name3, block_dimension=6)])
+                                     ArtificialFunction(name3, block_dimension=6)],
+                                     bad_values=[10000.]*3)
         for name1 in ["sphere", "cigar"]
         for name2 in ["sphere", "ellipsoid"]
         for name3 in ["sphere", "cigar", "hm"]

--- a/nevergrad/benchmark/experiments.py
+++ b/nevergrad/benchmark/experiments.py
@@ -6,6 +6,7 @@
 from typing import Iterator, Optional, List
 import nevergrad as ng
 from ..functions import ArtificialFunction
+from ..functions import multiobjective_minimization
 from ..functions import mlda as _mlda
 from ..functions.arcoating import ARCoating
 from ..functions import rl

--- a/nevergrad/benchmark/test_experiments.py
+++ b/nevergrad/benchmark/test_experiments.py
@@ -21,7 +21,7 @@ def test_experiments_registry(name: str, maker: Callable[[], Iterator[experiment
     with patch("shutil.which", return_value="here"):  # do not check for missing packages
         with datasets.mocked_data():  # mock mlda data that should be downloaded
             check_maker(maker)  # this is to extract the function for reuse if other external packages need it
-        if "mlda" not in name:
+        if "mlda" not in name and "moo" not in name:
             check_seedable(maker)  # this is a basic test on first elements, do not fully rely on it
 
 

--- a/nevergrad/functions/__init__.py
+++ b/nevergrad/functions/__init__.py
@@ -4,4 +4,5 @@
 # LICENSE file in the root directory of this source tree.
 
 from .functionlib import ArtificialFunction
+from .multiobjective import multiobjective_minimization
 from .utils import PostponedObject

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -70,6 +70,7 @@ def multiobjective_minimization(functions):
         def __init__(self):
             self.my_target_function = my_target_function
             super().__init__(self.my_target_function)
+            self._instrumentation = functions[0]._instrumentation 
         
     return my_instrumented_target_function
 

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -95,15 +95,16 @@ def multiobjective_minimization(functions, bad_values) -> InstrumentedFunction:
     my_target_function.pointset = []  # type: ignore
     my_target_function.best_hypervolume = 0  # type: ignore
 
-#    # Hack for returning an intrumenting function rather than just a lambda x: objective(x).
-#    class my_instrumented_target_function(InstrumentedFunction):
-#        def __init__(self):
-#            self.my_target_function = my_target_function
-#            super().__init__(self.my_target_function)
-#            if hasattr(functions[0], "instrumentation"):
-#                self._instrumentation = functions[0]._instrumentation 
-#
-#    return my_instrumented_target_function()
+    if hasattr(functions[0], "_instrumentation"):
+        # Hack for returning an intrumenting function rather than just a lambda x: objective(x).
+        class my_instrumented_target_function(InstrumentedFunction):
+            def __init__(self):
+                self.my_target_function = my_target_function
+                super().__init__(self.my_target_function)
+                self._instrumentation = functions[0]._instrumentation
+        return my_instrumented_target_function()
+
+    # Ok, so bad, we just return a callable.
     return my_target_function
 
 class _HyperVolume:

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -42,7 +42,7 @@ def hypervolume(pointset, ref=None):
     hv = _HyperVolume(ref)
     return hv.compute(pointset)
 
-def multiobjective_minimization(functions):
+def multiobjective_minimization(functions) --> InstrumentedFunction:
 
     def my_target_function(x=None):
         if x is None:

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -42,6 +42,7 @@ def hypervolume(pointset, ref=None):
 
 def multiobjective_minimization(functions, bad_values) -> InstrumentedFunction:
 
+    bad_values = numpy.array(bad_values)
     def my_target_function(x=None):
         if x is None:  # Then we return the Pareto front.
             contrib = []

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -38,7 +38,7 @@ def hypervolume(pointset, ref):
     hv = _HyperVolume(ref)
     return hv.compute(pointset)
 
-def multiobjective_minimization(functions, bad_values) -> Any:  #InstrumentedFunction:
+def multiobjective_minimization(functions, bad_values):  #InstrumentedFunction:
     """Given several functions, and threshold on their values (above which solutions are pointless),
     this function returns a single-objective function, correctly instrumented, the minimization of which
     yields a solution to the original multiobjective problem.

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -35,7 +35,7 @@ def hypervolume(pointset, ref=None):
     reference point *ref*.
     """
     if ref is None:
-        ref = numpy.array([3] * len(pointset[0]))
+        ref = numpy.array([3000000] * len(pointset[0]))
     warnings.warn("Falling back to the python version of hypervolume "
         "module. Expect this to be very slow.", RuntimeWarning)
     hv = _HyperVolume(ref)

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -40,13 +40,15 @@ def hypervolume(pointset, ref=None):
     hv = _HyperVolume(ref)
     return hv.compute(pointset)
 
-def multiobjective_minimization(functions, bad_values) -> InstrumentedFunction:
+def multiobjective_minimization(functions, bad_values, instrumentation=None) -> InstrumentedFunction:
     """Given several functions, and threshold on their values (above which solutions are pointless),
     this function returns a single-objective function, correctly instrumented, the minimization of which
     yields a solution to the original multiobjective problem.
     
     functions: objective functions, to be minimized, of the original multiobjective problem.
     bad_values: bad_values[i] is a threshold above which x is pointless if functions[i](x) > bad_values[i].
+    instrumentation: an instrumentation (simply the dimension, possibly, for a continuous problem). Not
+        mandatory, if functions[0] is equipped with an instrumentation.
     
     Returns an objective function to be minimized (it is a single objective function).
     Warning: this function is not stationary.
@@ -96,7 +98,7 @@ def multiobjective_minimization(functions, bad_values) -> InstrumentedFunction:
         def __init__(self):
             self.my_target_function = my_target_function
             super().__init__(self.my_target_function)
-            self._instrumentation = functions[0]._instrumentation 
+            self._instrumentation = instrumentation if instrumentation else functions[0]._instrumentation 
 
     return my_instrumented_target_function()
 

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -41,6 +41,20 @@ def hypervolume(pointset, ref=None):
     return hv.compute(pointset)
 
 def multiobjective_minimization(functions, bad_values) -> InstrumentedFunction:
+    """Given several functions, and threshold on their values (above which solutions are pointless),
+    this function returns a single-objective function, correctly instrumented, the minimization of which
+    yields a solution to the original multiobjective problem.
+    
+    functions: objective functions, to be minimized, of the original multiobjective problem.
+    bad_values: bad_values[i] is a threshold above which x is pointless if functions[i](x) > bad_values[i].
+    
+    Returns an objective function to be minimized (it is a single objective function).
+    Warning: this function is not stationary.
+    The minimum value obtained for this objective function is -h,
+    where h is the hypervolume of the Pareto front obtained, given bad_values as a reference point.
+    When called with no argument, this monoobjective function returns an approximate Pareto front,
+    reaching the current hypervolume.
+    """
 
     bad_values = numpy.array(bad_values)
     def my_target_function(x=None):

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -38,7 +38,7 @@ def hypervolume(pointset, ref):
     hv = _HyperVolume(ref)
     return hv.compute(pointset)
 
-def multiobjective_minimization(functions, bad_values) -> InstrumentedFunction:
+def multiobjective_minimization(functions, bad_values) -> Any:  #InstrumentedFunction:
     """Given several functions, and threshold on their values (above which solutions are pointless),
     this function returns a single-objective function, correctly instrumented, the minimization of which
     yields a solution to the original multiobjective problem.

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -37,8 +37,6 @@ def hypervolume(pointset, ref=None):
     """
     if ref is None:
         ref = numpy.array([3000000] * len(pointset[0]))
-    warnings.warn("Falling back to the python version of hypervolume "
-        "module. Expect this to be very slow.", RuntimeWarning)
     hv = _HyperVolume(ref)
     return hv.compute(pointset)
 
@@ -364,32 +362,3 @@ class _MultiList:
             if bounds[i] > node.cargo[i]:
                 bounds[i] = node.cargo[i]
             
-__all__ = ["hypervolume_kmax", "hypervolume"]
-
-if __name__ == "__main__":
-    f = multiobjective_minimization([lambda x: x[0], lambda x: x[1]])
-    for i in range(50000):
-        x = numpy.random.rand(3)
-        v = f(x)
-        if v < 0:  # we just print the best points (at least < 0)
-            print(x, v)
-    print("My Pareto front:", f())
-
-
-#    try:
-#        from deap.tools import hv
-#    except ImportError:
-#        hv = None
-#        print("Cannot import C version of hypervolume")
-#
-#    from deap.tools import sortLogNondominated
-#
-#    pointset = [(a, 1-a) for a in numpy.arange(1, 0, -0.0001)]
-#    ref = numpy.array([2, 2])
-#    print(pointset)
-#    print(("Python version: %f" % hypervolume(pointset, ref)))
-#    if hv:
-#        print(("C version: %f" % hv.hypervolume(pointset, ref)))
-#    print(("Approximated: %f" % hypervolume(pointset)))
-
-

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -82,8 +82,8 @@ def multiobjective_minimization(functions, bad_values) -> InstrumentedFunction:
             self.my_target_function = my_target_function
             super().__init__(self.my_target_function)
             self._instrumentation = functions[0]._instrumentation 
-        
-    return my_instrumented_target_function
+
+    return my_instrumented_target_function()
 
 class _HyperVolume:
     """

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -74,8 +74,8 @@ def multiobjective_minimization(functions, bad_values) -> InstrumentedFunction:
         return -my_hypervolume + numpy.sqrt(sum([a*a for a in vector_to_pareto]))
 
     # Initialization: at the beginning we have no Pareto front and no best hypervolume.
-    my_target_function.pointset = []
-    my_target_function.best_hypervolume = 0
+    my_target_function.pointset = []  # type: ignore
+    my_target_function.best_hypervolume = 0  # type: ignore
 
     # Hack for returning an intrumenting function rather than just a lambda x: objective(x).
     class my_instrumented_target_function(InstrumentedFunction):

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -24,6 +24,7 @@
 #
 #    Modified by O. Teytaud as needed for Nevergrad.
 
+from ..instrumentation import InstrumentedFunction
 from math import log, floor
 import random
 import warnings
@@ -64,7 +65,13 @@ def multiobjective_minimization(functions):
         return 0.
     my_target_function.pointset = []
     my_target_function.best_hypervolume = 0
-    return my_target_function
+
+    class my_instrumented_target_function(InstrumentedFunction):
+        def __init__(self):
+            self.my_target_function = my_target_function
+            super().__init__(self.my_target_function)
+        
+    return my_instrumented_target_function
 
 class _HyperVolume:
     """

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -71,7 +71,7 @@ def multiobjective_minimization(functions, bad_values) -> InstrumentedFunction:
             if all([y[i] <= v[i] for i in range(len(v))]):
                 for i in range(len(v)):
                     vector_to_pareto[i] = min(vector_to_pareto[i], v[i]-y[i])
-        return -my_hypervolume + numpy.sqrt(sum([a*a for a in distance_to_pareto]))
+        return -my_hypervolume + numpy.sqrt(sum([a*a for a in vector_to_pareto]))
 
     # Initialization: at the beginning we have no Pareto front and no best hypervolume.
     my_target_function.pointset = []

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -42,7 +42,7 @@ def hypervolume(pointset, ref=None):
     hv = _HyperVolume(ref)
     return hv.compute(pointset)
 
-def multiobjective_minimization(functions, bad_values) --> InstrumentedFunction:
+def multiobjective_minimization(functions, bad_values) -> InstrumentedFunction:
 
     def my_target_function(x=None):
         if x is None:  # Then we return the Pareto front.

--- a/nevergrad/functions/multiobjective.py
+++ b/nevergrad/functions/multiobjective.py
@@ -1,0 +1,374 @@
+#    This file is part of DEAP.
+#
+#    Copyright (C) 2010 Simon Wessing
+#    TU Dortmund University
+#
+#    In personal communication, the original authors authorized DEAP team
+#    to use this file under the Lesser General Public License.
+#
+#    You can find the original library here :
+#    http://ls11-www.cs.uni-dortmund.de/_media/rudolph/hypervolume/hv_python.zip
+#
+#    DEAP is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Lesser General Public License as
+#    published by the Free Software Foundation, either version 3 of
+#    the License, or (at your option) any later version.
+#
+#    DEAP is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with DEAP. If not, see <http://www.gnu.org/licenses/>.
+#
+#    Modified by O. Teytaud as needed for Nevergrad.
+
+from math import log, floor
+import random
+import warnings
+
+import numpy
+
+def hypervolume(pointset, ref=None):
+    """Compute the absolute hypervolume of a *pointset* according to the
+    reference point *ref*.
+    """
+    if ref is None:
+        ref = numpy.array([3] * len(pointset[0]))
+    warnings.warn("Falling back to the python version of hypervolume "
+        "module. Expect this to be very slow.", RuntimeWarning)
+    hv = _HyperVolume(ref)
+    return hv.compute(pointset)
+
+def multiobjective_minimization(functions):
+
+    def my_target_function(x=None):
+        if x is None:
+            contrib = []
+            for i in range(len(my_target_function.pointset)):
+                v = hypervolume(my_target_function.pointset[:i] + my_target_function.pointset[i+1:])
+                if v < my_target_function.best_hypervolume:
+                    contrib += [my_target_function.pointset[i]]
+            # print("Reducing Pareto front from ", len(my_target_function.pointset), " to ", len(contrib), ".")
+            my_target_function.pointset = contrib
+            return contrib
+        v = [f(x) for f in functions]
+        my_hypervolume = hypervolume(my_target_function.pointset + [v])
+        if my_hypervolume > my_target_function.best_hypervolume:
+            my_target_function.best_hypervolume = my_hypervolume
+            my_target_function.pointset += [v]
+            return -my_hypervolume
+        if numpy.random.rand() < 0.001:
+            my_target_function()
+        return 0.
+    my_target_function.pointset = []
+    my_target_function.best_hypervolume = 0
+    return my_target_function
+
+class _HyperVolume:
+    """
+    Hypervolume computation based on variant 3 of the algorithm in the paper:
+    C. M. Fonseca, L. Paquete, and M. Lopez-Ibanez. An improved dimension-sweep
+    algorithm for the hypervolume indicator. In IEEE Congress on Evolutionary
+    Computation, pages 1157-1163, Vancouver, Canada, July 2006.
+
+    Minimization is implicitly assumed here!
+
+    """
+
+    def __init__(self, referencePoint):
+        """Constructor."""
+        self.referencePoint = referencePoint
+        self.list = []
+
+
+    def compute(self, front):
+        """Returns the hypervolume that is dominated by a non-dominated front.
+
+        Before the HV computation, front and reference point are translated, so
+        that the reference point is [0, ..., 0].
+
+        """
+
+        def weaklyDominates(point, other):
+            for i in range(len(point)):
+                if point[i] > other[i]:
+                    return False
+            return True
+
+        relevantPoints = []
+        referencePoint = self.referencePoint
+        dimensions = len(referencePoint)
+        #######
+        # fmder: Here it is assumed that every point dominates the reference point
+        # for point in front:
+        #     # only consider points that dominate the reference point
+        #     if weaklyDominates(point, referencePoint):
+        #         relevantPoints.append(point)
+        relevantPoints = front
+        # fmder
+        #######
+        if any(referencePoint):
+            # shift points so that referencePoint == [0, ..., 0]
+            # this way the reference point doesn't have to be explicitly used
+            # in the HV computation
+            
+            #######
+            # fmder: Assume relevantPoints are numpy array
+            # for j in xrange(len(relevantPoints)):
+            #     relevantPoints[j] = [relevantPoints[j][i] - referencePoint[i] for i in xrange(dimensions)]
+            relevantPoints -= referencePoint
+            # fmder
+            #######
+
+        self.preProcess(relevantPoints)
+        bounds = [-1.0e308] * dimensions
+        hyperVolume = self.hvRecursive(dimensions - 1, len(relevantPoints), bounds)
+        return hyperVolume
+
+
+    def hvRecursive(self, dimIndex, length, bounds):
+        """Recursive call to hypervolume calculation.
+
+        In contrast to the paper, the code assumes that the reference point
+        is [0, ..., 0]. This allows the avoidance of a few operations.
+
+        """
+        hvol = 0.0
+        sentinel = self.list.sentinel
+        if length == 0:
+            return hvol
+        elif dimIndex == 0:
+            # special case: only one dimension
+            # why using hypervolume at all?
+            return -sentinel.next[0].cargo[0]
+        elif dimIndex == 1:
+            # special case: two dimensions, end recursion
+            q = sentinel.next[1]
+            h = q.cargo[0]
+            p = q.next[1]
+            while p is not sentinel:
+                pCargo = p.cargo
+                hvol += h * (q.cargo[1] - pCargo[1])
+                if pCargo[0] < h:
+                    h = pCargo[0]
+                q = p
+                p = q.next[1]
+            hvol += h * q.cargo[1]
+            return hvol
+        else:
+            remove = self.list.remove
+            reinsert = self.list.reinsert
+            hvRecursive = self.hvRecursive
+            p = sentinel
+            q = p.prev[dimIndex]
+            while q.cargo != None:
+                if q.ignore < dimIndex:
+                    q.ignore = 0
+                q = q.prev[dimIndex]
+            q = p.prev[dimIndex]
+            while length > 1 and (q.cargo[dimIndex] > bounds[dimIndex] or q.prev[dimIndex].cargo[dimIndex] >= bounds[dimIndex]):
+                p = q
+                remove(p, dimIndex, bounds)
+                q = p.prev[dimIndex]
+                length -= 1
+            qArea = q.area
+            qCargo = q.cargo
+            qPrevDimIndex = q.prev[dimIndex]
+            if length > 1:
+                hvol = qPrevDimIndex.volume[dimIndex] + qPrevDimIndex.area[dimIndex] * (qCargo[dimIndex] - qPrevDimIndex.cargo[dimIndex])
+            else:
+                qArea[0] = 1
+                qArea[1:dimIndex+1] = [qArea[i] * -qCargo[i] for i in range(dimIndex)]
+            q.volume[dimIndex] = hvol
+            if q.ignore >= dimIndex:
+                qArea[dimIndex] = qPrevDimIndex.area[dimIndex]
+            else:
+                qArea[dimIndex] = hvRecursive(dimIndex - 1, length, bounds)
+                if qArea[dimIndex] <= qPrevDimIndex.area[dimIndex]:
+                    q.ignore = dimIndex
+            while p is not sentinel:
+                pCargoDimIndex = p.cargo[dimIndex]
+                hvol += q.area[dimIndex] * (pCargoDimIndex - q.cargo[dimIndex])
+                bounds[dimIndex] = pCargoDimIndex
+                reinsert(p, dimIndex, bounds)
+                length += 1
+                q = p
+                p = p.next[dimIndex]
+                q.volume[dimIndex] = hvol
+                if q.ignore >= dimIndex:
+                    q.area[dimIndex] = q.prev[dimIndex].area[dimIndex]
+                else:
+                    q.area[dimIndex] = hvRecursive(dimIndex - 1, length, bounds)
+                    if q.area[dimIndex] <= q.prev[dimIndex].area[dimIndex]:
+                        q.ignore = dimIndex
+            hvol -= q.area[dimIndex] * q.cargo[dimIndex]
+            return hvol
+
+
+    def preProcess(self, front):
+        """Sets up the list data structure needed for calculation."""
+        dimensions = len(self.referencePoint)
+        nodeList = _MultiList(dimensions)
+        nodes = [_MultiList.Node(dimensions, point) for point in front]
+        for i in range(dimensions):
+            self.sortByDimension(nodes, i)
+            nodeList.extend(nodes, i)
+        self.list = nodeList
+
+
+    def sortByDimension(self, nodes, i):
+        """Sorts the list of nodes by the i-th value of the contained points."""
+        # build a list of tuples of (point[i], node)
+        decorated = [(node.cargo[i], node) for node in nodes]
+        # sort by this value
+        decorated.sort()
+        # write back to original list
+        nodes[:] = [node for (_, node) in decorated]
+            
+            
+            
+class _MultiList: 
+    """A special data structure needed by FonsecaHyperVolume. 
+    
+    It consists of several doubly linked lists that share common nodes. So, 
+    every node has multiple predecessors and successors, one in every list.
+
+    """
+
+    class Node: 
+        
+        def __init__(self, numberLists, cargo=None): 
+            self.cargo = cargo 
+            self.next  = [None] * numberLists
+            self.prev = [None] * numberLists
+            self.ignore = 0
+            self.area = [0.0] * numberLists
+            self.volume = [0.0] * numberLists
+    
+        def __str__(self): 
+            return str(self.cargo)
+
+        def __lt__(self, other):
+            return all(self.cargo < other.cargo)
+        
+    def __init__(self, numberLists):  
+        """Constructor. 
+        
+        Builds 'numberLists' doubly linked lists.
+
+        """
+        self.numberLists = numberLists
+        self.sentinel = _MultiList.Node(numberLists)
+        self.sentinel.next = [self.sentinel] * numberLists
+        self.sentinel.prev = [self.sentinel] * numberLists  
+        
+        
+    def __str__(self):
+        strings = []
+        for i in range(self.numberLists):
+            currentList = []
+            node = self.sentinel.next[i]
+            while node != self.sentinel:
+                currentList.append(str(node))
+                node = node.next[i]
+            strings.append(str(currentList))
+        stringRepr = ""
+        for string in strings:
+            stringRepr += string + "\n"
+        return stringRepr
+    
+    
+    def __len__(self):
+        """Returns the number of lists that are included in this _MultiList."""
+        return self.numberLists
+    
+    
+    def getLength(self, i):
+        """Returns the length of the i-th list."""
+        length = 0
+        sentinel = self.sentinel
+        node = sentinel.next[i]
+        while node != sentinel:
+            length += 1
+            node = node.next[i]
+        return length
+            
+            
+    def append(self, node, index):
+        """Appends a node to the end of the list at the given index."""
+        lastButOne = self.sentinel.prev[index]
+        node.next[index] = self.sentinel
+        node.prev[index] = lastButOne
+        # set the last element as the new one
+        self.sentinel.prev[index] = node
+        lastButOne.next[index] = node
+        
+        
+    def extend(self, nodes, index):
+        """Extends the list at the given index with the nodes."""
+        sentinel = self.sentinel
+        for node in nodes:
+            lastButOne = sentinel.prev[index]
+            node.next[index] = sentinel
+            node.prev[index] = lastButOne
+            # set the last element as the new one
+            sentinel.prev[index] = node
+            lastButOne.next[index] = node
+        
+        
+    def remove(self, node, index, bounds): 
+        """Removes and returns 'node' from all lists in [0, 'index'[."""
+        for i in range(index): 
+            predecessor = node.prev[i]
+            successor = node.next[i]
+            predecessor.next[i] = successor
+            successor.prev[i] = predecessor  
+            if bounds[i] > node.cargo[i]:
+                bounds[i] = node.cargo[i]
+        return node
+    
+    
+    def reinsert(self, node, index, bounds):
+        """
+        Inserts 'node' at the position it had in all lists in [0, 'index'[
+        before it was removed. This method assumes that the next and previous 
+        nodes of the node that is reinserted are in the list.
+
+        """
+        for i in range(index):
+            node.prev[i].next[i] = node
+            node.next[i].prev[i] = node
+            if bounds[i] > node.cargo[i]:
+                bounds[i] = node.cargo[i]
+            
+__all__ = ["hypervolume_kmax", "hypervolume"]
+
+if __name__ == "__main__":
+    f = multiobjective_minimization([lambda x: x[0], lambda x: x[1]])
+    for i in range(50000):
+        x = numpy.random.rand(3)
+        v = f(x)
+        if v < 0:  # we just print the best points (at least < 0)
+            print(x, v)
+    print("My Pareto front:", f())
+
+
+#    try:
+#        from deap.tools import hv
+#    except ImportError:
+#        hv = None
+#        print("Cannot import C version of hypervolume")
+#
+#    from deap.tools import sortLogNondominated
+#
+#    pointset = [(a, 1-a) for a in numpy.arange(1, 0, -0.0001)]
+#    ref = numpy.array([2, 2])
+#    print(pointset)
+#    print(("Python version: %f" % hypervolume(pointset, ref)))
+#    if hv:
+#        print(("C version: %f" % hv.hypervolume(pointset, ref)))
+#    print(("Approximated: %f" % hypervolume(pointset)))
+
+

--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -10,6 +10,7 @@ import numpy as np
 from bayes_opt import UtilityFunction
 from bayes_opt import BayesianOptimization
 from ..common.typetools import ArrayLike
+from ..functions import multiobjective_minimization
 from ..instrumentation import transforms
 from ..instrumentation import Instrumentation
 from . import utils


### PR DESCRIPTION
The doc of the main function says it all: this provides a simple tool for converting a multiobjective problem into a single objective one.

def multiobjective_minimization(functions, bad_values) -> InstrumentedFunction:
    """Given several functions, and threshold on their values (above which solutions are pointless),
    this function returns a single-objective function, correctly instrumented, the minimization of which
    yields a solution to the original multiobjective problem.
    
    functions: objective functions, to be minimized, of the original multiobjective problem.
    bad_values: bad_values[i] is a threshold above which x is pointless if functions[i](x) > bad_values[i].
    
    Returns an objective function to be minimized (it is a single objective function).
    Warning: this function is not stationary.
    The minimum value obtained for this objective function is -h,
    where h is the hypervolume of the Pareto front obtained, given bad_values as a reference point.
    When called with no argument, this monoobjective function returns an approximate Pareto front,
    reaching the current hypervolume.
    """


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

People at Dagstuhl's seminar on the Theory of Randomized Search Heuristics told me that this is a missing feature so I do it.

## How Has This Been Tested (if it applies)

I did not even check that what I do makes any sense.
It's very likely I am destroying the type testing.

## Checklist

- [x ] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
