### PR TITLE
Archive optimizer jobs in optimizer._archived_jobs

### DIFF
--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -230,6 +230,7 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
         # to make optimize function stoppable halway through
         self._running_jobs: List[Tuple[Candidate, JobLike[float]]] = []
         self._finished_jobs: Deque[Tuple[Candidate, JobLike[float]]] = deque()
+        self._archived_jobs: List[Tuple[Candidate, JobLike[float]]] = []
 
     @property
     def _rng(self) -> np.random.RandomState:
@@ -512,7 +513,7 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
                 while self._finished_jobs:
                     x, job = self._finished_jobs[0]
                     self.tell(x, job.result())
-                    self._finished_jobs.popleft()  # remove it after the tell to make sure it was indeed "told" (in case of interruption)
+                    self._archived_jobs.append(self._finished_jobs.popleft())  # remove it after the tell to make sure it was indeed "told" (in case of interruption)
                     if verbosity:
                         print(f"Updating fitness with value {job.result()}")
                 if verbosity:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

One recurring problem that I have is to access jobs after they are being told. For instance when the optimization is finished, sometime I need to retrieve all jobs that were started from the beginning.

## How Has This Been Tested (if it applies)

I ran multiple optimizations with this change

## Checklist

- [ ] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
