### PR TITLE
comparisons-only optimization

### DIFF
--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -389,11 +389,11 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
         best_fitness_value = 0
         for l in losers:
             if l in self.archive:
-                best_fitness_value = min(best_fitness_value, self.archive[l].get_estimation("average"))
+                best_fitness_value = min(best_fitness_value, self.archive[l.data].get_estimation("average"))
                 
         # Now let us decide the fitness value of winners.
         for i, w in enumerate(winners):
-            self.archive[w].add_evaluation(best_fitness_value - len(winners) + i)
+            self.archive[w.data].add_evaluation(best_fitness_value - len(winners) + i)
         
     def ask(self) -> Candidate:
         """Provides a point to explore.

--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -386,14 +386,14 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
         # This is for cases in which we do not know fitness values, we just know comparisons.
         
         # Evaluate the best fitness value among losers.
-        best_fitness_value = 0
+        best_fitness_value = 0.
         for l in losers:
-            if l in self.archive:
+            if l.data in self.archive:
                 best_fitness_value = min(best_fitness_value, self.archive[l.data].get_estimation("average"))
                 
         # Now let us decide the fitness value of winners.
         for i, w in enumerate(winners):
-            self.archive[w.data] = Value(best_fitness_value - len(winners) + i)
+            self.archive[w.data] = utils.Value(best_fitness_value - len(winners) + i)
         
     def ask(self) -> Candidate:
         """Provides a point to explore.

--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -381,20 +381,6 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
         if self.pruning is not None:
             self.archive = self.pruning(self.archive)
 
-    def compare(self, winners: List[Candidate], losers: List[Candidate]) -> None:
-        # This means that for any i and j, winners[i] is better than winners[i+1], and better than losers[j].
-        # This is for cases in which we do not know fitness values, we just know comparisons.
-        
-        # Evaluate the best fitness value among losers.
-        best_fitness_value = 0.
-        for l in losers:
-            if l.data in self.archive:
-                best_fitness_value = min(best_fitness_value, self.archive[l.data].get_estimation("average"))
-                
-        # Now let us decide the fitness value of winners.
-        for i, w in enumerate(winners):
-            self.archive[w.data] = utils.Value(best_fitness_value - len(winners) + i)
-        
     def ask(self) -> Candidate:
         """Provides a point to explore.
         This function can be called multiple times to explore several points in parallel
@@ -594,6 +580,27 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
         """
         warnings.warn("'optimize' method is deprecated, please use 'minimize' for clarity", DeprecationWarning)
         return self.minimize(objective_function, executor=executor, batch_mode=batch_mode, verbosity=verbosity)
+
+
+# Adding a comparison-only functionality to an optimizer.
+def addCompare(optimizer):
+
+    def compare(self, winners: List[Candidate], losers: List[Candidate]) -> None:
+        # This means that for any i and j, winners[i] is better than winners[i+1], and better than losers[j].
+        # This is for cases in which we do not know fitness values, we just know comparisons.
+        
+        # Evaluate the best fitness value among losers.
+        best_fitness_value = 0.
+        for l in losers:
+            if l.data in self.archive:
+                best_fitness_value = min(best_fitness_value, self.archive[l.data].get_estimation("average"))
+                
+        # Now let us decide the fitness value of winners.
+        for i, w in enumerate(winners):
+            self.tell(w, best_fitness_value - len(winners) + i)
+            self.archive[w.data] = utils.Value(best_fitness_value - len(winners) + i)
+
+    setattr(optimizer.__class__, 'compare', compare)
 
 
 class OptimizationPrinter:

--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -393,7 +393,7 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
                 
         # Now let us decide the fitness value of winners.
         for i, w in enumerate(winners):
-            self.archive[w.data].add_evaluation(best_fitness_value - len(winners) + i)
+            self.archive[w.data] = Value(best_fitness_value - len(winners) + i)
         
     def ask(self) -> Candidate:
         """Provides a point to explore.

--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -381,6 +381,20 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
         if self.pruning is not None:
             self.archive = self.pruning(self.archive)
 
+    def compare(self, winners: List[Candidate], losers: List[Candidate]) -> None:
+        # This means that for any i and j, winners[i] is better than winners[i+1], and better than losers[j].
+        # This is for cases in which we do not know fitness values, we just know comparisons.
+        
+        # Evaluate the best fitness value among losers.
+        best_fitness_value = 0
+        for l in losers:
+            if l in self.archive:
+                best_fitness_value = min(best_fitness_value, self.archive[l].get_estimation("average"))
+                
+        # Now let us decide the fitness value of winners.
+        for i, w in enumerate(winners):
+            self.archive[w].add_evaluation(best_fitness_value - len(winners) + i)
+        
     def ask(self) -> Candidate:
         """Provides a point to explore.
         This function can be called multiple times to explore several points in parallel

--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -17,6 +17,7 @@ from . import utils
 from . import base
 from . import mutations
 from .base import registry
+from .base import addCompare
 from .base import InefficientSettingsWarning
 from . import sequences
 

--- a/nevergrad/optimization/test_base.py
+++ b/nevergrad/optimization/test_base.py
@@ -115,6 +115,20 @@ def test_optimize_and_dump(tmp_path: Path) -> None:
     np.testing.assert_almost_equal(optimizer2.provide_recommendation().data[0], 1, decimal=2)
 
 
+def test_compare(tmp_path: Path) -> None:
+    optimizer = optimizerlib.CMA(instrumentation=3, budget=1000, num_workers=5)
+    optimizerlib.addCompare(optimizer)
+    for i in range(1000):
+        x = []
+        for j in range(6):
+            x += [optimizer.ask()]
+        winners = sorted(x, key=lambda x_: np.linalg.norm(x_.data-np.array((1.,1.,1.))))
+        optimizer.compare(winners[:3], winners[3:])
+    result = optimizer.provide_recommendation()
+    print(result)
+    np.testing.assert_almost_equal(result.data[0], 1., decimal=2)
+
+
 class StupidFamily(base.OptimizerFamily):
 
     def __call__(self, instrumentation: Union[int, Instrumentation], budget: Optional[int] = None, num_workers: int = 1) -> base.Optimizer:

--- a/nevergrad/optimization/test_base.py
+++ b/nevergrad/optimization/test_base.py
@@ -119,11 +119,11 @@ def test_compare(tmp_path: Path) -> None:
     optimizer = optimizerlib.CMA(instrumentation=3, budget=1000, num_workers=5)
     optimizerlib.addCompare(optimizer)
     for i in range(1000):
-        x = []
+        x: List[Any] = []
         for j in range(6):
             x += [optimizer.ask()]
         winners = sorted(x, key=lambda x_: np.linalg.norm(x_.data-np.array((1.,1.,1.))))
-        optimizer.compare(winners[:3], winners[3:])
+        optimizer.compare(winners[:3], winners[3:])  # type: ignore
     result = optimizer.provide_recommendation()
     print(result)
     np.testing.assert_almost_equal(result.data[0], 1., decimal=2)


### PR DESCRIPTION
Adding a comparison based operator for cases in which we do not have access to fitness values and just know the best points and their ranking.

@wangronin
@Dvermetten
@CarolaDoerr

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

We did a mathematical proof as follows:
1- let us consider that we use an elitist mu+lambda algorithm
2- let us assume that the compare function is always correctly called, in the sense that there is
   an underlying fitness function (the same for all iterations) such that fitness(winners[i]) < fitness(winners[i+1]) and fitness(winners[i]) < fitness(loser[j])
3- let us assume that there is no tie --- our algorithm never generates two points with same fitness value

Then: we prove that the fitness value as computed in "compare" make the algorithm equivalent to the case in which we provide the real unknown fitness values. 

Proof:
- completely trivial for an algorithm which just uses the ranks of the mu best (elitist mu+lambda, comparison-based)
- trivial also if we generate two points and compare them and update the internal state according to this  (CGA)
- does it work for e.g. pairwise comparison with population(epoch n, individual t) and population(epoch n-1, individual t) ? probably yes  (PSO or DE without best particle)
- what if we do comparisons between the ith individual at epoch n and the ith individual at epoch n-1, but we also keep track of the best so far ? (PSO or DE with best particle)



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
