### PR TITLE
Allow Scipy-based algorithms to recommend before starting

### DIFF
--- a/nevergrad/optimization/recaster.py
+++ b/nevergrad/optimization/recaster.py
@@ -232,10 +232,11 @@ class RecastOptimizer(base.Optimizer):
         """Returns the underlying optimizer output if provided (ie if the optimizer did finish)
         else the best pessimistic point.
         """
-        assert self._messaging_thread is not None, 'Optimization was not even started'
-        if self._messaging_thread.output is not None:
+        if (self._messaging_thread is not None and
+                self._messaging_thread.output is not None):
             return self._messaging_thread.output  # type: ignore
-        return self.current_bests["pessimistic"].x
+        else:
+            return self.current_bests["pessimistic"].x
 
     def __del__(self) -> None:
         # explicitly ask the thread to stop (better be safe :))

--- a/nevergrad/optimization/test_recaster.py
+++ b/nevergrad/optimization/test_recaster.py
@@ -81,3 +81,22 @@ def test_recast_optimizer_and_stop() -> None:
     optimizer = FakeOptimizer(instrumentation=2, budget=100)
     optimizer.ask()
     # thread is not finished... but should not hang!
+
+def test_provide_recommendation() -> None:
+    nevergrad_optimizer = optimizerlib.OnePlusOne(instrumentation=2, budget=100)
+    # even if no ask&tell, recommendation should work:
+    assert nevergrad_optimizer.provide_recommendation() is not None
+
+    # the recommended solution should be the better one among
+    # all told solutions for OnePlusOne solver:
+    x1 = nevergrad_optimizer.ask()
+    nevergrad_optimizer.tell(x1, 10)
+    x2 = nevergrad_optimizer.ask()
+    nevergrad_optimizer.tell(x2, 5)
+    recommended_solution = nevergrad_optimizer.provide_recommendation()
+    for i in range(len(recommended_solution.data)):
+        assert recommended_solution.data[i] == x2.data[i]
+
+    scipy_optimizer = optimizerlib.SQP(instrumentation=2, budget=100)
+    # even if no ask&tell, recommendation should work:
+    assert scipy_optimizer.provide_recommendation() is not None


### PR DESCRIPTION
## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Tried to address issue #444. At least the new test runs through :-)


## How Has This Been Tested (if it applies)

The new `test_recaster.py` has been written to cover the new code and passes `pytest`:
```
C:\Users\dimo\Desktop\nevergrad>pytest nevergrad\optimization\test_recaster.py
Test session starts (platform: win32, Python 3.7.3, pytest 4.3.1, pytest-sugar 0.9.2)
rootdir: C:\Users\dimo\Desktop\nevergrad, inifile:
plugins: sugar-0.9.2, remotedata-0.3.1, openfiles-0.3.2, mock-2.0.0, doctestplus-0.3.0, arraydiff-0.3, dash-1.3.1
collecting ...
nevergrad/optimization/test_recaster.py ✓                                                                 12% █▍         
nevergrad/optimization/test_recaster.py ✓✓                                                                25% ██▌        
nevergrad/optimization/test_recaster.py ✓✓✓                                                               38% ███▊       
nevergrad/optimization/test_recaster.py ✓✓✓✓                                                              50% █████      nevergrad/optimization/test_recaster.py ✓✓✓✓✓                                                             62% ██████▍    
nevergrad/optimization/test_recaster.py ✓✓✓✓✓✓                                                            75% ███████▌   
nevergrad/optimization/test_recaster.py ✓✓✓✓✓✓✓                                                           88% ████████▊  
nevergrad/optimization/test_recaster.py ✓✓✓✓✓✓✓✓                                                         100% ██████████

Results (3.76s):
       8 passed
```

Unfortunately, I could not run all tests on my Windows machine, because even without the new code, some tests fail (I will open a new related issue just after this).


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
      details: I did not manage to run all tests on my Windows machine (see additional issue, to be opened later). Moreover, even the suggested `mypy --implicit-reexport --strict nevergrad` did not run through due to some errors on files, I did not touch:
```
C:\Users\dimo\Desktop\nevergrad>pip install numpy-stubs
Collecting numpy-stubs
  Could not find a version that satisfies the requirement numpy-stubs (from versions: )
No matching distribution found for numpy-stubs

C:\Users\dimo\Desktop\nevergrad>mypy --implicit-reexport --strict nevergrad
nevergrad\functions\multiobjective\core.py:50: error: Returning Any from function declared to return "float"
nevergrad\optimization\oneshot.py:65: error: unused 'type: ignore' comment
nevergrad\optimization\oneshot.py:174: error: unused 'type: ignore' comment
nevergrad\optimization\optimizerlib.py:51: error: unused 'type: ignore' comment
nevergrad\benchmark\xpbase.py:218: error: Call to untyped function "manual_seed" in typed context
Found 5 errors in 4 files (checked 85 source files)
```
I leave this for a later commit.

I was also not sure whether to apply the autopep8 changes on the changed files. No changes were suggested on my lines, but quite many an the already existing ones. So I'll leave this to you (or your own pre-commit hooks).