### PR TITLE
Center and reduce standardized_space relatively to reference

### DIFF
--- a/nevergrad/instrumentation/core.py
+++ b/nevergrad/instrumentation/core.py
@@ -165,13 +165,12 @@ class Variable(p.Instrumentation):
     def kwargs(self) -> tp.Dict[str, tp.Any]:
         return {}
 
-    def _internal_get_standardized_data(self: T, instance: T) -> np.ndarray:
-        return instance.data
+    def _internal_get_standardized_data(self: T, reference: T) -> np.ndarray:  # pylint: disable=unused-argument
+        return self.data - reference.data  # type: ignore
 
-    def _internal_set_standardized_data(self: T, data: np.ndarray, instance: T, deterministic: bool = False) -> T:
-        instance._data = data
-        instance._value = instance.data_to_arguments(instance.data, deterministic=deterministic)
-        return instance
+    def _internal_set_standardized_data(self: T, data: np.ndarray, reference: T, deterministic: bool = False) -> None:
+        self._data = data + reference.data
+        self._value = self.data_to_arguments(self.data, deterministic=deterministic)
 
     def _internal_spawn_child(self: T) -> T:
         child = copy.deepcopy(self)

--- a/nevergrad/parametrization/container.py
+++ b/nevergrad/parametrization/container.py
@@ -128,7 +128,7 @@ class Instrumentation(Tuple):
         """Converts args and kwargs into data in np.ndarray format
         """
         self._compatibility.value = (args, kwargs)
-        return self._compatibility.get_standardized_data()
+        return self._compatibility.get_standardized_data(reference=self)
 
     def data_to_arguments(self, data: ArrayLike, deterministic: bool = False) -> ArgsKwargs:
         """Converts data to arguments
@@ -146,7 +146,7 @@ class Instrumentation(Tuple):
         kwargs: Dict[str, Any]
             the keyword arguments corresponding to the instance initialization keyword arguments
         """
-        self._compatibility.set_standardized_data(np.array(data, copy=False), deterministic=deterministic)
+        self._compatibility.set_standardized_data(np.array(data, copy=False), reference=self, deterministic=deterministic)
         return self._compatibility.value  # type: ignore
 
     def set_cheap_constraint_checker(self, func: tp.Callable[..., bool]) -> None:

--- a/nevergrad/parametrization/core.py
+++ b/nevergrad/parametrization/core.py
@@ -113,9 +113,9 @@ class Parameter:
         Parameters
         ----------
         reference: Parameter
-            the reference to represent in the standardized data space. By default this is "self", but other
-            instances of the same type can be passed so as to be able to perform operations between them in the
-            standardized data space (see note below)
+            the reference instance for representation in the standardized data space. By default this is "self",
+            hence by default this method returns a zero vector, but you can represent the instance with respect to another
+            reference point, and operation between instances should always be from data relative to a unique reference
 
         Returns
         -------
@@ -124,9 +124,8 @@ class Parameter:
 
         Note
         ----
-        Operations between different standardized data should only be performed if at least one of these conditions apply:
-        - internal/model parameters do not mutate (eg: sigma is constant)
-        - each array was produced by the same reference in the exact same state (no mutation)
+        - Operations between different standardized data should only be performed if each array was produced
+          by the same reference in the exact same state (no mutation)
         - to make the code more explicit, the "reference" parameter is enforced as a keyword-only parameter.
         """
         assert reference is None or isinstance(reference, self.__class__), f"Expected {type(self)} but got {type(reference)} as reference"
@@ -143,7 +142,7 @@ class Parameter:
         np.ndarray
             the representation of the value in the optimization space
         reference: Parameter
-            the reference to update ("self", if not provided)
+            the reference point for representing the data ("self", if not provided)
         deterministic: bool
             whether the value should be deterministically drawn (max probability) in the case of stochastic parameters
 


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

`[get/set]_standardized_data` acts on `self` instead of `instance`, and takes a `reference` as input
instead of the `instance`. The standardized space is now also centered around the `reference`

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesisate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
