### PR TITLE
MOO: autocomputation of the reference point

### DIFF
--- a/nevergrad/functions/multiobjective/core.py
+++ b/nevergrad/functions/multiobjective/core.py
@@ -51,8 +51,8 @@ class MultiobjectiveFunction:
         and update the state of the function with new points if it belongs to the pareto front
         """
         # We compute the hypervolume
-        if self.auto_bound > 0:
-            self.auto_bound -= 1
+        if self._auto_bound > 0:
+            self._auto_bound -= 1
             self._upper_bounds = np.maximum(self._upper_bounds, np.array(losses))
         if (losses - self._upper_bounds > 0).any():
             return np.max(losses - self._upper_bounds)  # type: ignore

--- a/nevergrad/functions/multiobjective/core.py
+++ b/nevergrad/functions/multiobjective/core.py
@@ -53,7 +53,10 @@ class MultiobjectiveFunction:
         # We compute the hypervolume
         if self._auto_bound > 0:
             self._auto_bound -= 1
-            self._upper_bounds = np.maximum(self._upper_bounds, np.array(losses))
+            if self._upper_bounds is not None:
+                self._upper_bounds = np.maximum(self._upper_bounds, np.array(losses))
+            else:
+                self._upper_bounds = np.array(losses)
         if (losses - self._upper_bounds > 0).any():
             return np.max(losses - self._upper_bounds)  # type: ignore
         arr_losses = np.minimum(np.array(losses, copy=False), self._upper_bounds)

--- a/nevergrad/functions/multiobjective/core.py
+++ b/nevergrad/functions/multiobjective/core.py
@@ -53,10 +53,7 @@ class MultiobjectiveFunction:
         # We compute the hypervolume
         if self._auto_bound > 0:
             self._auto_bound -= 1
-            if self._upper_bounds is not None:
-                self._upper_bounds = np.maximum(self._upper_bounds, np.array(losses))
-            else:
-                self._upper_bounds = np.array(losses)
+            self._upper_bounds = np.maximum(self._upper_bounds, np.array(losses))
                 
         if (losses - self._upper_bounds > 0).any():
             return np.max(losses - self._upper_bounds)  # type: ignore

--- a/nevergrad/functions/multiobjective/core.py
+++ b/nevergrad/functions/multiobjective/core.py
@@ -34,9 +34,14 @@ class MultiobjectiveFunction:
       remotely, and aggregate locally. This is what happens in the "minimize" method of optimizers.
     """
 
-    def __init__(self, multiobjective_function: Callable[..., ArrayLike], upper_bounds: ArrayLike) -> None:
+    def __init__(self, multiobjective_function: Callable[..., ArrayLike], upper_bounds: Optional[ArrayLike] = None) -> None:
         self.multiobjective_function = multiobjective_function
-        self._upper_bounds = np.array(upper_bounds, copy=False)
+        if upper_bounds is None:
+            self._upper_bounds = None
+            self._auto_bound = 10
+        else:
+            self._upper_bounds = np.array(upper_bounds, copy=False)
+            self._auto_bound = 0
         self._hypervolume: Any = HypervolumeIndicator(self._upper_bounds)  # type: ignore
         self._points: List[Tuple[ArgsKwargs, np.ndarray]] = []
         self._best_volume = -float("Inf")
@@ -46,6 +51,9 @@ class MultiobjectiveFunction:
         and update the state of the function with new points if it belongs to the pareto front
         """
         # We compute the hypervolume
+        if self.auto_bound > 0:
+            self.auto_bound -= 1
+            self._upper_bounds = np.maximum(self._upper_bounds, np.array(losses))
         if (losses - self._upper_bounds > 0).any():
             return np.max(losses - self._upper_bounds)  # type: ignore
         arr_losses = np.minimum(np.array(losses, copy=False), self._upper_bounds)

--- a/nevergrad/functions/multiobjective/core.py
+++ b/nevergrad/functions/multiobjective/core.py
@@ -45,7 +45,7 @@ class MultiobjectiveFunction:
             self._upper_bounds = np.array(upper_bounds, copy=False)
             self._lower_bounds = np.array(upper_bounds, copy=False)
             self._auto_bound = 0
-        self._hypervolume: Any = HypervolumeIndicator(self._upper_bounds)  # type: ignore
+            self._hypervolume: Any = HypervolumeIndicator(self._upper_bounds)  # type: ignore
         self._points: List[Tuple[ArgsKwargs, np.ndarray]] = []
         self._best_volume = -float("Inf")
 

--- a/nevergrad/functions/multiobjective/core.py
+++ b/nevergrad/functions/multiobjective/core.py
@@ -37,7 +37,7 @@ class MultiobjectiveFunction:
     def __init__(self, multiobjective_function: Callable[..., ArrayLike], upper_bounds: Optional[ArrayLike] = None) -> None:
         self.multiobjective_function = multiobjective_function
         if upper_bounds is None:
-            self._upper_bounds = None
+            self._upper_bounds = np.array([0.])
             self._auto_bound = 10
         else:
             self._upper_bounds = np.array(upper_bounds, copy=False)
@@ -57,6 +57,7 @@ class MultiobjectiveFunction:
                 self._upper_bounds = np.maximum(self._upper_bounds, np.array(losses))
             else:
                 self._upper_bounds = np.array(losses)
+                
         if (losses - self._upper_bounds > 0).any():
             return np.max(losses - self._upper_bounds)  # type: ignore
         arr_losses = np.minimum(np.array(losses, copy=False), self._upper_bounds)

--- a/nevergrad/functions/multiobjective/test_core.py
+++ b/nevergrad/functions/multiobjective/test_core.py
@@ -52,3 +52,10 @@ def test_doc_multiobjective() -> None:
     assert len(f.pareto_front(2, "domain-covering")) == 2
     assert len(f.pareto_front(2, "hypervolume")) == 2
     assert len(f.pareto_front(2, "random")) == 2
+
+    # We can also run without upper_bounds: they are then computed automatically using "_auto_bound".
+    f = MultiobjectiveFunction(multiobjective_function=lambda x: [np.sum(x**2), np.sum((x - 1)**2)])
+    optimizer = ng.optimizers.CMA(parametrization=3, budget=100)  # 3 is the dimension, 100 is the budget.
+    optimizer.minimize(f)
+    assert len(f.pareto_front()) > 1
+


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Computing the reference point is complicated.
Why not using the maximum of the 10 first losses vectors sampled by the optimization algorithms ?

## How Has This Been Tested (if it applies)

just the CI, because I have no time :-/

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
