### PR TITLE
Simplify crossover

### DIFF
--- a/nevergrad/functions/arcoating/core.py
+++ b/nevergrad/functions/arcoating/core.py
@@ -61,12 +61,12 @@ class ARCoating(ExperimentFunction):
         self.ep0 = 1
         self.epf = 9
         self.epmin = 1
-        init = (self.epmin + self.epf) / 2.0 * np.ones((1, nbslab))
+        init = (self.epmin + self.epf) / 2.0 * np.ones((nbslab,))
         sigma = (self.epf - self.ep0) / 6
         array = ng.p.Array(init=init, mutable_sigma=True,)
         array.set_mutation(sigma=sigma)
         array.set_bounds(self.epmin, self.epf, method=bounding_method, full_range_sampling=True)
-        array.set_recombination(Crossover(2, structured_dimensions=(0,))).set_name("")
+        array.set_recombination(Crossover(0)).set_name("")
         super().__init__(self._get_minimum_average_reflexion, array)
         self.register_initialization(nbslab=nbslab, d_ar=d_ar, bounding_method=bounding_method)
         self._descriptors.update(nbslab=nbslab, d_ar=d_ar, bounding_method=bounding_method)

--- a/nevergrad/functions/arcoating/test_core.py
+++ b/nevergrad/functions/arcoating/test_core.py
@@ -34,7 +34,7 @@ def test_arcoating_recombination() -> None:
         arrays.append(func.parametrization.spawn_child())  # type: ignore
         arrays[-1].value = num * np.ones(arrays[0].value.shape)
     arrays[0].recombine(arrays[1])
-    expected = [[3., 3., 5., 5., 5., 3.]]
+    expected = [3., 3., 3., 5., 3., 3.]
     np.testing.assert_array_equal(arrays[0].value, expected)
 
 

--- a/nevergrad/functions/photonics/core.py
+++ b/nevergrad/functions/photonics/core.py
@@ -64,7 +64,7 @@ def _make_parametrization(name: str, dimension: int, bounding_method: str = "cli
         # sigma must be adapted for clipping and constraint methods
         array.set_mutation(sigma=p.Array(init=[[10.0]] if name != "bragg" else [[0.03], [10.0]]).set_mutation(exponent=2.0))  # type: ignore
     array.set_bounds(b_array[:, [0]], b_array[:, [1]], method=bounding_method, full_range_sampling=True)
-    array.set_recombination(Crossover(2, structured_dimensions=(0,))).set_name("")
+    array.set_recombination(Crossover(axis=1)).set_name("")
     assert array.dimension == dimension, f"Unexpected {array} for dimension {dimension}"
     return array
 
@@ -120,6 +120,14 @@ class Photonics(ExperimentFunction):
         super().__init__(self._compute, _make_parametrization(name=name, dimension=dimension, bounding_method=bounding_method))
         self.register_initialization(name=name, dimension=dimension, bounding_method=bounding_method)
         self._descriptors.update(name=name, bounding_method=bounding_method)
+
+    # pylint: disable=arguments-differ
+    def evaluation_function(self, x: np.ndarray) -> float:  # type: ignore
+        loss = self.function(x)
+        datastr = ", ".join([str(x) for x in x.ravel()])
+        string = f"# {self.name}([{datastr}]) = {loss}"
+        print(string)  # log this for the record
+        return loss
 
     def _compute(self, x: np.ndarray) -> float:
         x_cat = x.ravel()

--- a/nevergrad/functions/photonics/test_core.py
+++ b/nevergrad/functions/photonics/test_core.py
@@ -62,7 +62,7 @@ def test_photonics_recombination() -> None:
         arrays.append(func.parametrization.spawn_child())  # type: ignore
         arrays[-1].value = num * np.ones(arrays[0].value.shape)
     arrays[0].recombine(arrays[1])
-    expected = [71, 50, 71, 71]
+    expected = [71, 50, 50, 50]
     np.testing.assert_array_equal(arrays[0].value, np.ones((4, 1)).dot(np.array(expected)[None, :]))
 
 
@@ -95,6 +95,7 @@ def test_photonics_values(name: str, value: float, expected: float) -> None:
         raise SkipTest("Too slow in CircleCI")
     photo = core.Photonics(name, 16)
     np.testing.assert_almost_equal(photo(value * np.ones(16)), expected, decimal=4)
+    np.testing.assert_almost_equal(photo.evaluation_function(value * np.ones(16)), expected, decimal=4)
 
 
 GOOD_CHIRPED = [89.04887416, 109.54188095, 89.74520725, 121.81700431,

--- a/nevergrad/parametrization/test_utils.py
+++ b/nevergrad/parametrization/test_utils.py
@@ -73,44 +73,24 @@ def test_flatten_parameter_order(order: int, keys: tp.Iterable[str]) -> None:
 def test_crossover() -> None:
     x1 = 4 * np.ones((2, 3))
     x2 = 5 * np.ones((2, 3))
-    co = utils.Crossover(0, (0,))
+    co = utils.Crossover(axis=1)
     out = co.apply((x1, x2), rng=np.random.RandomState(12))
-    expected = np.ones((2, 1)).dot([[5, 5, 4]])
+    expected = np.ones((2, 1)).dot([[4, 5, 4]])
     np.testing.assert_array_equal(out, expected)
 
 
-def test_random_crossover() -> None:
-    arrays = [k * np.ones((2, 2)) for k in range(30)]
-    co = utils.Crossover(0)
-    out = co.apply(arrays)
-    assert 0 in out
-
-
 @testing.parametrized(
-    p2i2=(42, 2, 2, [0, 0, 1, 1, 1, 0]),
-    p5i6=(42, 5, 6, [3, 0, 1, 2, 5, 4]),
-    p1i2=(42, 1, 2, [0, 0, 1, 1, 1, 1]),
-    p2i3=(42, 2, 3, [1, 1, 2, 2, 2, 0]),
-    p3i2=(42, 2, 2, [0, 0, 1, 1, 1, 0]),
+    all_none=(None, None),
+    d2=((1, 2), None),
+    d1=((1), None),
 )
-def test_kpoint_crossover(seed: int, points: int, indiv: int, expected: tp.List[int]) -> None:
-    rng = np.random.RandomState(seed)
-    crossover = utils.Crossover(points)
-    donors = [k * np.ones(len(expected)) for k in range(indiv)]
-    output = crossover.apply(donors, rng)
-    np.testing.assert_array_equal(output, expected)
-
-
-@testing.parametrized(
-    small=(1, 5, [0]),
-    keep_first=(2, 1000, [0, 871]),
-    two_points=(3, 2, [0, 1, 0]),
-    two_points_big=(3, 1000, [518, 871, 0]),
-)
-def test_make_crossover_sequence(num_sections: int, num_individuals: int, expected: tp.List[int]) -> None:
-    rng = np.random.RandomState(12)
-    out = utils._make_crossover_sequence(num_sections=num_sections, num_individuals=num_individuals, rng=rng)
-    assert out == expected
+def test_crossover_axis(axis: tp.Optional[tp.Tuple[int, ...]], max_size: tp.Optional[int]) -> None:
+    shape = (6, 8, 10)
+    x1 = 4 * np.ones(shape)
+    x2 = 5 * np.ones(shape)
+    co = utils.Crossover(axis=axis, max_size=max_size)
+    out = co.apply((x1, x2), rng=np.random.RandomState(12))
+    np.testing.assert_array_equal(out.shape, shape)  # this basically only test that it did not raise an error
 
 
 def test_descriptors() -> None:

--- a/nevergrad/parametrization/utils.py
+++ b/nevergrad/parametrization/utils.py
@@ -170,33 +170,34 @@ class Crossover:
     """ Experimental, the API will evolve
     """
 
-    def __init__(self, num_points: int = 0, structured_dimensions: tp.Iterable[int] = ()) -> None:
-        self.num_points = num_points
-        self.structured_dimensions = sorted(structured_dimensions)
+    def __init__(self, axis: tp.Optional[tp.Union[int, tp.Iterable[int]]]) -> None:
+        self.axis = (axis,) if isinstance(axis, int) else axis
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.num_points}, {self.structured_dimensions})"
+        return f"{self.__class__.__name__}({self.axis})"
 
     def apply(self, arrays: tp.Sequence[np.ndarray], rng: tp.Optional[np.random.RandomState] = None) -> np.ndarray:
-        if len(arrays) > 30:
-            warnings.warn("Crossover can only handle up to 30 arrays")
-            arrays = arrays[:30]
+        arrays = list(arrays)
+        if len(arrays) != 2:
+            raise Exception("Crossover can only be applied between 2 individuals")
+        assert array[0].shape == array[1].shape, "Individuals should have the same shape"
         if rng is None:
             rng = np.random.RandomState()
-        shape = tuple(d for k, d in enumerate(arrays[0].shape) if k not in self.structured_dimensions)
-        choices = np.zeros(shape, dtype=int)
+        axis = tuple(range(array[0].dim)
+
+
         if not self.num_points:
-            choices = rng.randint(0, len(arrays), size=choices.shape)
+            choices=rng.randint(0, len(arrays), size=choices.shape)
             if 0 not in choices:
-                choices.ravel()[rng.randint(choices.size)] = 0  # always involve first element
+                choices.ravel()[rng.randint(choices.size)]=0  # always involve first element
         elif choices.ndim == 1:
-            bounds = sorted(rng.choice(shape[0] - 1, size=self.num_points, replace=False).tolist())  # 0 to n - 2
-            bounds = [0] + [1 + b for b in bounds] + [shape[0]]
-            indices = _make_crossover_sequence(len(bounds) - 1, len(arrays), rng)
+            bounds=sorted(rng.choice(shape[0] - 1, size=self.num_points, replace=False).tolist())  # 0 to n - 2
+            bounds=[0] + [1 + b for b in bounds] + [shape[0]]
+            indices=_make_crossover_sequence(len(bounds) - 1, len(arrays), rng)
             for start, end, index in zip(bounds[:-1], bounds[1:], indices):
-                choices[start:end] = index
+                choices[start:end]=index
         else:
             raise NotImplementedError
         for d in self.structured_dimensions:
-            choices = np.expand_dims(choices, d)
+            choices=np.expand_dims(choices, d)
         return np.choose(choices, arrays)  # type:ignore

--- a/nevergrad/parametrization/utils.py
+++ b/nevergrad/parametrization/utils.py
@@ -7,7 +7,6 @@ import os
 import sys
 import shutil
 import tempfile
-import warnings
 import subprocess
 import typing as tp
 from pathlib import Path
@@ -152,52 +151,69 @@ class CommandFunction:
         return stdout
 
 
-def _make_crossover_sequence(num_sections: int, num_individuals: int, rng: np.random.RandomState) -> tp.List[int]:
-    assert num_individuals > 1
-    indices = rng.permutation(num_individuals).tolist()
-    while len(indices) < num_sections:
-        new_indices = rng.permutation(num_individuals).tolist()
-        if new_indices[0] == indices[-1]:
-            new_indices[0], new_indices[-1] = new_indices[-1], new_indices[0]
-        indices.extend(new_indices)
-    indices = indices[:num_sections]
-    if 0 not in indices:
-        indices[rng.randint(num_sections)] = 0  # always involve first element
-    return indices  # type: ignore
-
-
 class Crossover:
-    """ Experimental, the API will evolve
+    """Operator for merging part of an array into another one
+
+    Parameters
+    ----------
+    axis: None or int or tuple of ints
+        the axis (or axes) on which the merge will happen. This axis will be split into 3 parts: the first and last one will take
+        value from the first array, the middle one from the second array.
+    max_size: None or int
+        maximum size of the part taken from the second array. By default, this is at most around half the number of total elements of the
+        array to the power of 1/number of axis.
+
+
+    Notes
+    -----
+    - this is experimental, the API may evolve
+    - when using several axis, the size of the second array part is the same on each axis (aka a square in 2D, a cube in 3D, ...)
+
+    Examples:
+    ---------
+    - 2-dimensional array, with crossover on dimension 1:
+      0 1 0 0
+      0 1 0 0
+      0 1 0 0
+    - 2-dimensional array, with crossover on dimensions 0 and 1:
+      0 0 0 0
+      0 1 1 0
+      0 1 1 0
+
+
     """
 
-    def __init__(self, axis: tp.Optional[tp.Union[int, tp.Iterable[int]]]) -> None:
-        self.axis = (axis,) if isinstance(axis, int) else axis
+    def __init__(self, axis: tp.Optional[tp.Union[int, tp.Iterable[int]]] = None, max_size: tp.Optional[int] = None) -> None:
+        self.axis = (axis,) if isinstance(axis, int) else tuple(axis) if axis is not None else None
+        self.max_size = max_size
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.axis})"
 
     def apply(self, arrays: tp.Sequence[np.ndarray], rng: tp.Optional[np.random.RandomState] = None) -> np.ndarray:
+        # checks
         arrays = list(arrays)
         if len(arrays) != 2:
             raise Exception("Crossover can only be applied between 2 individuals")
-        assert array[0].shape == array[1].shape, "Individuals should have the same shape"
+        shape = arrays[0].shape
+        assert shape == arrays[1].shape, "Individuals should have the same shape"
+        # settings
         if rng is None:
             rng = np.random.RandomState()
-        axis = tuple(range(array[0].dim)
-
-
-        if not self.num_points:
-            choices=rng.randint(0, len(arrays), size=choices.shape)
-            if 0 not in choices:
-                choices.ravel()[rng.randint(choices.size)]=0  # always involve first element
-        elif choices.ndim == 1:
-            bounds=sorted(rng.choice(shape[0] - 1, size=self.num_points, replace=False).tolist())  # 0 to n - 2
-            bounds=[0] + [1 + b for b in bounds] + [shape[0]]
-            indices=_make_crossover_sequence(len(bounds) - 1, len(arrays), rng)
-            for start, end, index in zip(bounds[:-1], bounds[1:], indices):
-                choices[start:end]=index
-        else:
-            raise NotImplementedError
-        for d in self.structured_dimensions:
-            choices=np.expand_dims(choices, d)
-        return np.choose(choices, arrays)  # type:ignore
+        axis = tuple(range(len(shape))) if self.axis is None else self.axis
+        max_size = int(((arrays[0].size + 1) / 2)**(1 / len(axis))) if self.max_size is None else self.max_size
+        max_size = min(max_size, *(shape[a] - 1 for a in axis))
+        size = 1 if max_size == 1 else rng.randint(1, max_size)
+        # slices
+        slices = []
+        for a, s in enumerate(shape):
+            if a in axis:
+                if s <= 1:
+                    raise ValueError("Cannot crossover an shape with size 1")
+                start = rng.randint(s - size)
+                slices.append(slice(start, start + size))
+            else:
+                slices.append(slice(0, s))
+        result = np.array(arrays[0], copy=True)
+        result[tuple(slices)] = arrays[1][tuple(slices)]
+        return result


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

This reimplements crossovers with a simplified API and scope.
We now only deal with 2 points crossover of 2 individuals, in any dimension, while we could before perform k-points crossover of n individuals but only in 1 dimension.
The code is simpler as well, and there is no clear impact of integrating other cases (more than 2 individuals and more points).

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
