### PR TITLE
[WIP]prune descriptors

### DIFF
--- a/nevergrad/benchmark/plotting.py
+++ b/nevergrad/benchmark/plotting.py
@@ -188,7 +188,7 @@ def create_plots(
     for d in all_descriptors:
         acceptable = False
         for b in df.budget.unique():
-            if len(loc[df[‘budget’] == b][d].unique()) > 0:
+            if len(loc[df['budget'] == b][d].unique()) > 0:
                 acceptable = True
                 break
         if acceptable:

--- a/nevergrad/benchmark/plotting.py
+++ b/nevergrad/benchmark/plotting.py
@@ -175,15 +175,25 @@ def create_plots(
     descriptors = sorted(set(df.columns) - (required | {"seed", "pseudotime"}))  # all other columns are descriptors
     to_drop = [x for x in descriptors if len(df.unique(x)) == 1]
     df = utils.Selector(df.loc[:, [x for x in df.columns if x not in to_drop]])
-    descriptors = sorted(set(df.columns) - (required | {"seed", "pseudotime"}))  # now those should be actual interesting descriptors
-    print(f"Descriptors: {descriptors}")
+    all_descriptors = sorted(set(df.columns) - (required | {"seed", "pseudotime"}))  # now those should be actual interesting descriptors
+    print(f"Descriptors: {all_descriptors}")
     print("# Fight plots")
     #
     # fight plot
     # choice of the combination variables to fix
-    fight_descriptors = descriptors + ["budget"]  # budget can be used as a descriptor for fight plots
-    TODO remove descriptors which have only one value for each budget ?
+    fight_descriptors = all_descriptors + ["budget"]  # budget can be used as a descriptor for fight plots
     combinable = [x for x in fight_descriptors if len(df.unique(x)) > 1]  # should be all now
+    # We remove descriptors which have only one value for each budget.
+    descriptors = []
+    for d in all_descriptors:
+        acceptable = False
+        for b in df.budget.unique():
+            if len(loc[df[‘budget’] == b][d].unique()) > 0:
+                acceptable = True
+                break
+        if acceptable:
+            descriptors += [d]
+    
     num_rows = 6
 
     # For the competence map case we must consider pairs of attributes, hence maxcomb_size >= 2.

--- a/nevergrad/benchmark/plotting.py
+++ b/nevergrad/benchmark/plotting.py
@@ -188,12 +188,11 @@ def create_plots(
     for d in all_descriptors:
         acceptable = False
         for b in df.budget.unique():
-            if len(df.loc[df['budget'] == b][d].unique()) > 0:
+            if len(df.loc[df['budget'] == b][d].unique()) > 1:
                 acceptable = True
                 break
         if acceptable:
             descriptors += [d]
-    
     num_rows = 6
 
     # For the competence map case we must consider pairs of attributes, hence maxcomb_size >= 2.

--- a/nevergrad/benchmark/plotting.py
+++ b/nevergrad/benchmark/plotting.py
@@ -188,7 +188,7 @@ def create_plots(
     for d in all_descriptors:
         acceptable = False
         for b in df.budget.unique():
-            if len(loc[df['budget'] == b][d].unique()) > 0:
+            if len(df.loc[df['budget'] == b][d].unique()) > 0:
                 acceptable = True
                 break
         if acceptable:

--- a/nevergrad/benchmark/plotting.py
+++ b/nevergrad/benchmark/plotting.py
@@ -182,6 +182,7 @@ def create_plots(
     # fight plot
     # choice of the combination variables to fix
     fight_descriptors = descriptors + ["budget"]  # budget can be used as a descriptor for fight plots
+    TODO remove descriptors which have only one value for each budget ?
     combinable = [x for x in fight_descriptors if len(df.unique(x)) > 1]  # should be all now
     num_rows = 6
 


### PR DESCRIPTION
Nevergrad provides plots as follows:
* x-axis = budget
* y-axis = regret
We do this separately for each test case.
Unfortunately, in some cases, we prefer to have several test cases gathered on the same plot.
This is the case in particular in one-shot optimization: we do not want to separate test cases which corresponds to different parallelisms, because the parallelism is equal to the budget.
So, we remove descriptors which are uniquely determined by the budget.
This should remove num_workers from the descriptors, when num_workers = budget.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

in some sense a bugfix, as the result was technically correct but not consistent with what users want.

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

The one-shot setting is the key motivation.

## How Has This Been Tested (if it applies)

Just the CI.

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
