### PR TITLE
Make bouncing the default for constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   Still, some optimizers (like `TBPSA`) may recommend a non-evaluated point.
 - `Choice` now takes a new `repetitions` parameters for sampling several times,
   it is equivalent to :code:`Tuple(*[Choice(options) for _ in range(repetitions)])` but can be be around 30x faster for large numbers of repetitions [#670](https://github.com/facebookresearch/nevergrad/pull/670).
+- Defaults for bounds in `Array` is now `bouncing`, which is a variant of `clipping` avoiding over-sompling on the bounds [#684](https://github.com/facebookresearch/nevergrad/pull/684)
+  and [#691](https://github.com/facebookresearch/nevergrad/pull/691).
 
 
 ## 0.4.1 (2019-05-07)

--- a/nevergrad/parametrization/data.py
+++ b/nevergrad/parametrization/data.py
@@ -204,7 +204,7 @@ class Array(core.Parameter):
         self: A,
         lower: BoundValue = None,
         upper: BoundValue = None,
-        method: str = "clipping",
+        method: str = "bouncing",
         full_range_sampling: tp.Optional[bool] = None,
         a_min: BoundValue = None,
         a_max: BoundValue = None,
@@ -220,10 +220,10 @@ class Array(core.Parameter):
         method: str
             One of the following choices:
 
+            - "bouncing": bounce on border (at most once). This is a variant of clipping,
+               avoiding bounds over-samping (default).
             - "clipping": clips the values inside the bounds. This is efficient but leads
               to over-sampling on the bounds.
-            - "bouncing": bounce on border (at most once). This is an experimental variant of clipping,
-               avoiding bounds over-samping.
             - "constraint": adds a constraint (see register_cheap_constraint) which leads to rejecting mutations
               reaching beyond the bounds. This avoids oversampling the boundaries, but can be inefficient in large
               dimension.


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

This is a follow-up of #684 making `bouncing` the default for bounding constraints. Hard clipping on the bounds can lead to very detrimental loss of diversity. Bouncing on the border can help avoid this in being closer to an actual constraint through resampling, while being much more efficient in large dimension
Closes #621 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
