### PR TITLE
Fixed the spelling of advised

### DIFF
--- a/nevergrad/parametrization/core.py
+++ b/nevergrad/parametrization/core.py
@@ -277,7 +277,7 @@ class Parameter:
         - constraints should be fast to compute.
         """
         if getattr(func, "__name__", "not lambda") == "<lambda>":  # LambdaType does not work :(
-            warnings.warn("Lambda as constraint is not adviced because it may not be picklable.")
+            warnings.warn("Lambda as constraint is not advised because it may not be picklable.")
         self._constraint_checkers.append(func)
 
     # %% random state

--- a/nevergrad/parametrization/data.py
+++ b/nevergrad/parametrization/data.py
@@ -363,7 +363,7 @@ class Array(core.Parameter):
         Note
         ----
         Using integer casting makes the parameter discrete which can make the optimization more
-        difficult. It is especially ill-adviced to use this with a range smaller than 10, or
+        difficult. It is especially ill-advised to use this with a range smaller than 10, or
         a sigma lower than 1. In those cases, you should rather use a TransitionChoice instead.
         """
         self.integer = True

--- a/nevergrad/parametrization/test_param_doc.py
+++ b/nevergrad/parametrization/test_param_doc.py
@@ -80,7 +80,7 @@ def test_param_example() -> None:
     #  'char': 'a'}
 
     # increase the step/sigma for array
-    # (note that it's adviced to to this during the creation
+    # (note that it's advised to to this during the creation
     #  of the variable:
     #  array=ng.p.Array(shape=(2,)).set_mutation(sigma=10))
     param["array"].set_mutation(sigma=10)  # type: ignore


### PR DESCRIPTION
One occurrence is in a code comment
One occurrence is in a docstring
One occurrence is in a public-facing warning

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue
This fixes spelling in a public-facing warning. I also went ahead and fixed all of the occurrence of this misspelling in the code base

## How Has This Been Tested (if it applies)
N/A
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
