### PR TITLE
Fix erroneous RL test

### DIFF
--- a/nevergrad/functions/rl/agents.py
+++ b/nevergrad/functions/rl/agents.py
@@ -128,6 +128,7 @@ class TorchAgentFunction(ExperimentFunction):
         try:  # safeguard against nans
             with torch.no_grad():
                 reward = self.runner.run(self.agent)
+
         except RuntimeError as e:
             warnings.warn(f"Returning 0 after error: {e}")
             reward = 0.0

--- a/nevergrad/functions/rl/test_agents.py
+++ b/nevergrad/functions/rl/test_agents.py
@@ -51,7 +51,7 @@ def test_torch_agent_function() -> None:
     args, kwargs = instru.spawn_child().set_standardized_data([0] * instru.dimension).value
     assert not args
     value = agentfunction.compute(**kwargs)
-    assert value in [0, 1]
+    assert value in [0, -1]   # negated reward, for minimization
     # optimization
     opt = optimizerlib.OnePlusOne(instru, budget=10)
     opt.minimize(agentfunction.compute)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

New pytorch version has more randomness in a test and rightfully broke it since the test was erroneous.
#769 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
