### PR TITLE
Include tuple in one of the examples

### DIFF
--- a/docs/parametrization.rst
+++ b/docs/parametrization.rst
@@ -102,7 +102,7 @@ Let's define the parametrization for a function taking 3 positional arguments an
 - :code:`arg1 = ng.p.Choice([["Helium", "Nitrogen", "Oxygen"]])` is the first positional argument, which can take 3 possible values, without any order, the selection is made stochasticly through the sampling of a softmax. It is encoded by 3 values (the softmax weights) in the "standardized space".
 - :code:`arg2 = ng.p.TransitionChoice(["Solid", "Liquid", "Gas"])` is the second one, it encodes the choice (i.e. 1 dimension) through a single index which can mutate in a continuous way.
 - third argument will be kept constant to :code:`blublu`
-- :code:`values = ng.p.Tuple(ng.p.Scalar(), ng.p.Scalar())` which represents a tuple of two scalars both in the parameter space, and in the "standardized space"
+- :code:`values = ng.p.Tuple(ng.p.Scalar().set_integer_casting(), ng.p.Scalar())` which represents a tuple of two scalars with different numeric types in the parameter space, and in the "standardized space"
 
 We then define a parameter holding all these parameters, with a standardized space of dimension 6 (as the sum of the dimensions above):
 
@@ -135,7 +135,7 @@ With this code:
 
 - :code:`Nitrogen` is selected because proba(e) = exp(80) / (exp(80) + exp(-80) + exp(-80)) = 1
 - :code:`Liquid` is selected because the index for `Liquid` is around 0 in the standardized space.
-- :code:`dimension=(3.0, 5.0)` because the last two values of the standardized space (i.e. 3.0, 5.0) corresponds to the value of the last kwargs.
+- :code:`amount=(3, 5.0)` because the last two values of the standardized space (i.e. 3.0, 5.0) corresponds to the value of the last kwargs.
 
 
 Parametrizing external code

--- a/docs/parametrization.rst
+++ b/docs/parametrization.rst
@@ -99,12 +99,12 @@ where it is easier to define operations.
 
 Let's define the parametrization for a function taking 3 positional arguments and one keyword argument :code:`value`.
 
-- :code:`arg1 = ng.p.TransitionChoice(["a", "b"])` is the first positional argument, it encodes the choice through a single index which can mutate in a continuous way.
-- :code:`arg2 = ng.p.Choice(["a", "c", "e"])` is the second one, which can take 3 possible values, without any order, the selection is made stochasticly through the sampling of a softmax. It is encoded by 3 values (the softmax weights) in the "standardized space"
-- third argument will be kept constant to :code:` blublu`
-- :code:`value = ng.p.Scalar()` which represents a scalar both in the parameter space, and in the "standardized space"
+- :code:`arg1 = ng.p.Choice([["Helium", "Nitrogen", "Oxygen"]])` is the first positional argument, which can take 3 possible values, without any order, the selection is made stochasticly through the sampling of a softmax. It is encoded by 3 values (the softmax weights) in the "standardized space".
+- :code:`arg2 = ng.p.TransitionChoice(["Solid", "Liquid", "Gas"])` is the second one, it encodes the choice (i.e. 1 dimension) through a single index which can mutate in a continuous way.
+- third argument will be kept constant to :code:`blublu`
+- :code:`values = ng.p.Tuple(ng.p.Scalar(), ng.p.Scalar())` which represents a tuple of two scalars both in the parameter space, and in the "standardized space"
 
-We then define a parameter holding all these parameters, with a standardized space of dimension 5 (as the sum of the dimensions above):
+We then define a parameter holding all these parameters, with a standardized space of dimension 6 (as the sum of the dimensions above):
 
 .. literalinclude:: ../nevergrad/optimization/test_doc.py
     :language: python
@@ -133,9 +133,9 @@ Here is a glipse of what happens on the optimization space:
 
 With this code:
 
-- :code:`b` is selected because 1 > 0 (the index is 1 for values above 0, and 0 for values under 0 since there are 2 values).
-- :code:`e` is selected because proba(e) = exp(80) / (exp(80) + exp(-80) + exp(-80)) = 1
-- :code:`value=3` because the last value of the standardized space (i.e. 3) corresponds to the value of the last kwargs.
+- :code:`Nitrogen` is selected because proba(e) = exp(80) / (exp(80) + exp(-80) + exp(-80)) = 1
+- :code:`Liquid` is selected because the index for `Liquid` is around 0 in the standardized space.
+- :code:`dimension=(3.0, 5.0)` because the last two values of the standardized space (i.e. 3.0, 5.0) corresponds to the value of the last kwargs.
 
 
 Parametrizing external code

--- a/docs/parametrization.rst
+++ b/docs/parametrization.rst
@@ -123,7 +123,7 @@ You can then directly perform optimization on a function given its parametrizati
     :end-before: DOC_PARAM_2
 
 
-Here is a glipse of what happens on the optimization space:
+Here is a glimpse of what happens on the optimization space:
 
 .. literalinclude:: ../nevergrad/optimization/test_doc.py
     :language: python

--- a/nevergrad/optimization/test_doc.py
+++ b/nevergrad/optimization/test_doc.py
@@ -100,27 +100,27 @@ def test_print_all_optimizers() -> None:
 
 def test_parametrization() -> None:
     # DOC_PARAM_0
-    arg1 = ng.p.TransitionChoice(["a", "b"])
-    arg2 = ng.p.Choice(["a", "c", "e"])
-    value = ng.p.Scalar()
+    arg1 = ng.p.Choice(["Helium", "Nitrogen", "Oxygen"])
+    arg2 = ng.p.TransitionChoice(["Solid", "Liquid", "Gas"])
+    values = ng.p.Tuple(ng.p.Scalar(), ng.p.Scalar())
 
-    instru = ng.p.Instrumentation(arg1, arg2, "blublu", value=value)
+    instru = ng.p.Instrumentation(arg1, arg2, "blublu", dimension=values)
     print(instru.dimension)
-    # >>> 5
+    # >>> 6
     # DOC_PARAM_1
 
-    def myfunction(arg1, arg2, arg3, value=3):
+    def myfunction(arg1, arg2, arg3, dimension=(2, 2)):
         print(arg1, arg2, arg3)
-        return value**2
+        return dimension[0]**2 + dimension[1]**2
 
     optimizer = ng.optimizers.OnePlusOne(parametrization=instru, budget=100)
     recommendation = optimizer.minimize(myfunction)
     print(recommendation.value)
-    # >>> (('b', 'e', 'blublu'), {'value': -0.00014738768964717153})
+    # >>> (('Helium', 'Gas', 'blublu'), {'value': (-0.00014738768964717153, 0.0006602471804655007)})
     # DOC_PARAM_2
-    instru2 = instru.spawn_child().set_standardized_data([1, -80, -80, 80, 3])
-    assert instru2.args == ('b', 'e', 'blublu')
-    assert instru2.kwargs == {'value': 3}
+    instru2 = instru.spawn_child().set_standardized_data([-80, 80, -80, 0, 3.0, 5.0])
+    assert instru2.args == ('Nitrogen', 'Liquid', 'blublu')
+    assert instru2.kwargs == {'dimension': (3.0, 5.0)}
     # DOC_PARAM_3
 
 

--- a/nevergrad/optimization/test_doc.py
+++ b/nevergrad/optimization/test_doc.py
@@ -102,25 +102,25 @@ def test_parametrization() -> None:
     # DOC_PARAM_0
     arg1 = ng.p.Choice(["Helium", "Nitrogen", "Oxygen"])
     arg2 = ng.p.TransitionChoice(["Solid", "Liquid", "Gas"])
-    values = ng.p.Tuple(ng.p.Scalar(), ng.p.Scalar())
+    values = ng.p.Tuple(ng.p.Scalar().set_integer_casting(), ng.p.Scalar())
 
-    instru = ng.p.Instrumentation(arg1, arg2, "blublu", dimension=values)
+    instru = ng.p.Instrumentation(arg1, arg2, "blublu", amount=values)
     print(instru.dimension)
     # >>> 6
     # DOC_PARAM_1
 
-    def myfunction(arg1, arg2, arg3, dimension=(2, 2)):
+    def myfunction(arg1, arg2, arg3, amount=(2, 2)):
         print(arg1, arg2, arg3)
-        return dimension[0]**2 + dimension[1]**2
+        return amount[0]**2 + amount[1]**2
 
     optimizer = ng.optimizers.OnePlusOne(parametrization=instru, budget=100)
     recommendation = optimizer.minimize(myfunction)
     print(recommendation.value)
-    # >>> (('Helium', 'Gas', 'blublu'), {'value': (-0.00014738768964717153, 0.0006602471804655007)})
+    # >>> (('Helium', 'Gas', 'blublu'), {'value': (0, 0.0006602471804655007)})
     # DOC_PARAM_2
-    instru2 = instru.spawn_child().set_standardized_data([-80, 80, -80, 0, 3.0, 5.0])
+    instru2 = instru.spawn_child().set_standardized_data([-80, 80, -80, 0, 3, 5.0])
     assert instru2.args == ('Nitrogen', 'Liquid', 'blublu')
-    assert instru2.kwargs == {'dimension': (3.0, 5.0)}
+    assert instru2.kwargs == {'amount': (3, 5.0)}
     # DOC_PARAM_3
 
 


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue
1. Missing a simple example of Parametrization using `ng.p.Tuple` in the documentation.
2. Found two typos in the example

## How Has This Been Tested (if it applies)
test_doc.py is modified accordingly to test the modified example.

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
