### PR TITLE
Use compile() to speed up the value assignment function of Pyomo

### DIFF
--- a/nevergrad/functions/pyomo/core.py
+++ b/nevergrad/functions/pyomo/core.py
@@ -131,7 +131,7 @@ class Pyomo(base.ExperimentFunction):
         if len(self.all_objectives) > 1:
             raise NotImplementedError("Multi-objective function is not supported yet.")
 
-        self._value_assignment_code_obj = None
+        self._value_assignment_code_obj = ""
 
         instru = p.Instrumentation(**instru_params)
         for c_idx in range(0, len(self.all_constraints)):
@@ -146,7 +146,7 @@ class Pyomo(base.ExperimentFunction):
 
 
     def _pyomo_value_assignment(self, k_model_variables: tp.Dict[str, tp.Any]) -> None:
-        if self._value_assignment_code_obj is None:
+        if self._value_assignment_code_obj == "":
             code_str = ""
             for k in k_model_variables:
                 code_str += f"self._model_instance.{k} = k_model_variables['{k}']\n"

--- a/nevergrad/functions/pyomo/core.py
+++ b/nevergrad/functions/pyomo/core.py
@@ -168,7 +168,7 @@ class Pyomo(base.ExperimentFunction):
             return bool(pyomo.value(self.all_constraints[i].expr(self._model_instance)))
         elif isinstance(self.all_constraints[i], pyomo.base.constraint.IndexedConstraint):
             ret = True
-            for k, c in self.all_constraints[i].items():
+            for _, c in self.all_constraints[i].items():
                 ret = ret and pyomo.value(c.expr(self._model_instance))
                 if not ret:
                     break


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue
Issue: https://github.com/facebookresearch/nevergrad/pull/804
teytaud mentioned that "pmedian with size 30 fails by time exceeded".  The crux of the problem is that some optimizers do not generate solutions that satisfy the constraints, but faster value assignment helps in general.

Before the change, exec() is called repeatedly to assign value to each variable to the model instance. In this commit, the raw Python code is first compiled. The value assignment function will then execute on the compiled object. Based on the results of my rough benchmarking experiment, this will save 8%-10% of the total running time.

## How Has This Been Tested (if it applies)
The existing tests of Pyomo are passed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [ ] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
