### PR TITLE
[Open Optimization Competition 2020] - Nevergrad Performance Capture Benchmark

### DIFF
--- a/nevergrad/benchmark/frozenexperiments.py
+++ b/nevergrad/benchmark/frozenexperiments.py
@@ -12,8 +12,65 @@ from nevergrad.functions import ArtificialFunction
 from .xpbase import registry
 from .xpbase import create_seed_generator
 from .xpbase import Experiment
+from .perfcap.experiments import perfcap_experiment
+
 # pylint: disable=stop-iteration-return, too-many-nested-blocks
 
+
+@registry.register
+def perfcap_bench1(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
+    seedg = create_seed_generator(seed)
+    return perfcap_experiment("experiment1.json", seedg)
+
+@registry.register
+def perfcap_bench2(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
+    seedg = create_seed_generator(seed)
+    return perfcap_experiment("experiment2.json", seedg)
+
+@registry.register
+def perfcap_bench3(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
+    seedg = create_seed_generator(seed)
+    return perfcap_experiment("experiment3.json", seedg)
+
+@registry.register
+def perfcap_bench4(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
+    seedg = create_seed_generator(seed)
+    return perfcap_experiment("experiment4.json", seedg)
+
+@registry.register
+def perfcap_bench5(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
+    seedg = create_seed_generator(seed)
+    return perfcap_experiment("experiment5.json", seedg)
+
+@registry.register
+def perfcap_bench6(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
+    seedg = create_seed_generator(seed)
+    return perfcap_experiment("experiment6.json", seedg)
+
+@registry.register
+def perfcap_bench7(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
+    seedg = create_seed_generator(seed)
+    return perfcap_experiment("experiment7.json", seedg)
+
+@registry.register
+def perfcap_bench8(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
+    seedg = create_seed_generator(seed)
+    return perfcap_experiment("experiment8.json", seedg)
+
+@registry.register
+def perfcap_bench9(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
+    seedg = create_seed_generator(seed)
+    return perfcap_experiment("experiment9.json", seedg)
+
+@registry.register
+def perfcap_bench10(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
+    seedg = create_seed_generator(seed)
+    return perfcap_experiment("experiment10.json", seedg)
+
+@registry.register
+def perfcap_bench11(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
+    seedg = create_seed_generator(seed)
+    return perfcap_experiment("experiment11.json", seedg)
 
 @registry.register
 def basic(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:

--- a/nevergrad/benchmark/perfcap/core.py
+++ b/nevergrad/benchmark/perfcap/core.py
@@ -1,0 +1,460 @@
+#################################################################
+# Author: Alex Doumanoglou (al3x.doum@gmail.com / aldoum@iti.gr)
+# Information Technologies Institute - Visual Computing Lab (https://vcl.iti.gr)
+# 30 Sept 2020
+#################################################################
+import json
+import os
+import pathlib
+import typing as tp
+#import threading
+import logging
+import sys
+import traceback
+import itertools
+import copy
+from enum import Enum
+from uuid import uuid4 as uuid_gen
+from nevergrad.benchmark.perfcap.rmqservice import RMQService as _RMQService, RMQSettings as _RMQSettings
+import nevergrad as ng
+from nevergrad.benchmark.xpbase import Experiment
+from nevergrad.optimization import base as obase
+from nevergrad import functions as ngfuncs
+
+
+class Status(Enum):
+    OK = 0
+    Failed = 1
+
+
+class PerfcapExperiment(Experiment):
+
+    #pylint: disable=too-many-arguments
+    def __init__(self,
+                 experiment_manager: 'ExperimentManager',
+                 function: 'PerfcapFunction',
+                 optimizer: tp.Union[str, obase.ConfiguredOptimizer], budget: int, num_workers: int = 1,
+                 batch_mode: bool = True, seed: tp.Optional[int] = None,
+                 ) -> None:
+
+        kvps = {key: value for (key, value) in locals().items() if key not in ('experiment_manager', 'self', '__class__')}
+        super().__init__(**kvps)
+        self._experiment_manager = experiment_manager
+
+    def run(self) -> tp.Dict[str, tp.Any]:
+        try:
+            self._experiment_manager._start_experiment(self.function.experiment_tag_id)        # try to setup experiment
+        except Exception as e:  # pylint: disable=broad-except
+                                                            # experiment setup failed
+            self.result["error"] = e.__class__.__name__     # log error
+            print(f"Error when applying {self}:", file=sys.stderr)
+            traceback.print_exc()
+            print("\n", file=sys.stderr)
+            self._experiment_manager._stop_experiment(self.function.experiment_tag_id)     # disable rmq service if needed
+            return self.get_description()
+
+        ret = super().run()
+        # print the case and the traceback
+        # stop experiment. submit recommendation of the optimizer to Perfcap Benchmark Server in order for the server
+        # to dump the animated mesh in its mesh logs.
+        self._experiment_manager._stop_experiment(self.function.experiment_tag_id,
+                                                  self.function.compute_pose(*self.recommendation.value[0]))
+
+        return ret
+
+
+class VarNormalizer:
+    """
+    Normalizes parameter values to range [-1.0,1.0] based on bounds
+    This may improve optimizer convergence when scaling is different across parameters (i.e translation vs rotation)
+    Can be silently deactivated if normalize is set to False in the constructor.
+    """
+
+    def __init__(self, lower_bound: float, upper_bound: float, normalize: bool = False):
+        """
+        lower_bound: variable lower bound
+        upper_bound: variable upper bound
+        normalize: if False VarNormalizer is deactivated. If True, it will normalize input values in [-1.0,1.0
+        """
+        self._lower_bound = lower_bound
+        self._upper_bound = upper_bound
+        self._normalize = normalize
+
+    def denormalize(self, val: float) -> float:
+        """
+        Denormalize the parameter val
+        val: value to denormalize
+
+        Returns denormalized value
+        """
+        if not self._normalize:
+            return val
+        else:
+            return (val+1)*(self._upper_bound-self._lower_bound)/2.0 + self._lower_bound
+
+    def normalize(self, val: float) -> float:
+        """
+        Normalize the parameter val
+        val: value to normalize
+
+        Returns normalize value
+        """
+        if not self._normalize:
+            return val
+        else:
+            return 2.0 * (val - self.lower_bound) / (self._upper_bound - self._lower_bound) - 1.0
+
+    @property
+    def lower_bound(self):
+        return self._lower_bound
+
+    @property
+    def upper_bound(self):
+        return self._upper_bound
+
+    @property
+    def active_lower_bound(self):
+        """
+        effective lower variable bound
+        """
+        if self._normalize:
+            return -1.0
+        else:
+            return self._lower_bound
+
+    @property
+    def active_upper_bound(self):
+        """
+        effective upper variable bound
+        """
+
+        if self._normalize:
+            return 1.0
+        else:
+            return self._upper_bound
+
+    @property
+    def active(self):
+        """
+        Returns True, if VarNormalizer is effective
+        """
+        return self._normalize
+
+# pylint:disable=too-many-instance-attributes
+
+
+class PerfcapFunction(ngfuncs.ExperimentFunction):
+    """
+    Performance Capture Objective Function. This appears as a blocking call to the caller.
+    However, under the hood, it does a network request via ExperimentManager's RMQService to
+    Perfcap Benchmark Server to get the function evaluation at the specified point
+    """
+    # pylint:disable=too-many-locals
+
+    def _create_parameters(self, cfg: tp.Dict[str, tp.Any]) -> tp.List[ng.p.Scalar]:
+        """
+        Creates the parameters for the objective function based on configuration read from experimentX.json
+        """
+        variables = cfg["variables"]
+        jids = list(map(lambda x: x["joint_id"], variables))
+        jidset = set(jids)
+        assert len(jids) == len(jidset)
+        for v in variables:
+            # joint rotation exponential map has at most 3 degrees of freedom (DOF). Each DOF corresponds to one potential parameter.
+            # ["DOFs"] is a boolean list of length 3, indicating which one of the joint axis
+            # are considered for rotation. We can disable degrees of freedom per joint by
+            # inserting False to the related position index inside this list
+            # mutation_variances/bounds_min/bounds_max/mutable_mutation_variances
+            # are arrays of lenth equal to the number of DOFs of the joint
+            assert len(v["DOFs"]) == 3
+            nvars = sum(map(lambda x: 1 if x else 0, v["DOFs"]))
+
+            assert len(v["mutation_variances"]) == nvars
+            assert len(v["bounds_min"]) == nvars
+            assert len(v["bounds_max"]) == nvars
+            assert len(v["mutable_mutation_variances"]) == nvars
+
+        initial_pose = self._initial_pose
+        dofs_flattened = list(itertools.chain(*map(lambda x: x["DOFs"], variables)))
+        jids_flattened = list(itertools.chain(*map(lambda x: [x["joint_id"]]*len(list(filter(None, x["DOFs"]))), variables)))
+        #var_indices_flattend = list(np.cumsum(np.array(list(map(lambda x: 1 if x else 0, dofs_flattened))))-1)
+        var_indices_flattened = list(range(len(jids_flattened)))
+        dof_indices_flattened = list(itertools.chain(*map(lambda x: [index for index, v in enumerate(x["DOFs"]) if v], variables)))
+        self._variable_to_dof_index_map = dict(zip(var_indices_flattened, dof_indices_flattened))
+        self._variable_to_joint_index_map = dict(zip(var_indices_flattened, jids_flattened))
+        initial_values = list(itertools.compress(itertools.chain(*(initial_pose[jid] for jid in jids)), dofs_flattened))
+        # initial_values
+        #joint_vars = list(map(lambda x: sum(map(lambda y: 1 if y else 0, x["DOFs"])), variables))
+        bounds_min = list(itertools.chain(*map(lambda x: x["bounds_min"], variables)))
+        bounds_max = list(itertools.chain(*map(lambda x: x["bounds_max"], variables)))
+        mutation_variances = list(itertools.chain(*map(lambda x: x["mutation_variances"], variables)))
+        mutable_mut_var = list(itertools.chain(*map(lambda x: x["mutable_mutation_variances"], variables)))
+        # parameter normalizers, one for each parameter
+        self._var_normalizers = [VarNormalizer(lower_bound=x[0], upper_bound=x[1], normalize=self._normalize)
+                                 for x in zip(bounds_min, bounds_max)]
+        # parameter creation (initial value, bounds, mutable_mutation_var)
+        p = [ng.p.Scalar(init=n.normalize(init), lower=n.active_lower_bound, upper=n.active_upper_bound, mutable_sigma=ms)
+             for (n, ms, init) in zip(self._var_normalizers, mutable_mut_var, initial_values)]
+        # leave negative mutation variances to auto / ie. do not set
+        for (v, mv, n) in filter(lambda x: x[1] > 0.0, zip(p, mutation_variances, self._var_normalizers)):
+            v.set_mutation(n.normalize(mv), custom="gaussian")      # set variable mutation
+
+        return p
+
+    def __init__(self, experiment_manager: 'ExperimentManager', experiment_func_cfg: tp.Dict[str, tp.Any], experiment_tag_id: str):
+
+        self._initial_pose: tp.Dict[int, tp.List[float]] = dict(map(lambda o: (o["joint_id"], o["values"]),
+                                                                    experiment_func_cfg["initial_pose"]))
+        self._relative_search_space: bool = experiment_func_cfg["relative_search_space"]
+        self._normalize: bool = experiment_func_cfg["normalize"]
+        self._var_normalizers: tp.List[VarNormalizer] = None
+        self._variable_to_dof_index_map: tp.Dict[int, int] = None
+        self._variable_to_joint_index_map: tp.Dict[int, int] = None
+        self._experiment_tag_id: str = experiment_tag_id
+        self._experiment_manager = experiment_manager
+
+        p = self._create_parameters(experiment_func_cfg)
+        super().__init__(self.oracle_call, ng.p.Instrumentation(*p))
+        self.register_initialization(experiment_manager=experiment_manager,
+                                     experiment_func_cfg=experiment_func_cfg,
+                                     experiment_tag_id=experiment_tag_id)  # to create equivalent instances through "copy"
+        # self._descriptors.update(experiment_func_cfg=experiment_func_cfg, "\{experiment_tag_id\}" = experiment_tag_id)
+        self._descriptors.update(experiment_func_cfg=experiment_func_cfg)   # append experiment_func_cfg to ExperimentFunction descriptors
+        # exclude experiment_tag_id from fight descriptors by encapsulating its name inside "{ }"
+        self._descriptors[r"{experiment_tag_id}"] = experiment_tag_id       # append experiment_tag_id to ExperimentFunction descritors.
+        # put name inside "{}", to exclude from fightplots (plotting.py has been updated accordingly)
+
+    @property
+    def experiment_tag_id(self):
+        return self._experiment_tag_id
+
+    def compute_pose(self, *args) -> tp.Dict[int, tp.List[float]]:
+        """
+        This function will translate Optimizer's parameter arguments to animatable mesh pose.
+        """
+        eval_point = copy.deepcopy(self._initial_pose)  # deep copy         # start from initial_pose
+
+        # DOF values that are not set to True in configuration re not touched from the optimizer's evaluation point
+        # and are left to the value of the initial pose
+        for (v, n, var_index) in zip(args, self._var_normalizers, range(len(args))):
+            jid = self._variable_to_joint_index_map[var_index]
+            vi = self._variable_to_dof_index_map[var_index]
+            v = n.denormalize(v)
+            # update evaluation_point based on values of the parameters
+            if self._relative_search_space:
+                eval_point[jid][vi] += v
+            else:
+                eval_point[jid][vi] = v
+
+        return eval_point
+
+    def oracle_call(self, *args):
+        """Implements the call of the function.
+        Under the hood, __call__ delegates to oracle_call + add some noise if noise_level > 0.
+        """
+
+        eval_point = self.compute_pose(*args)
+        errors = self._experiment_manager._request_function_evaluation(eval_point, self._experiment_tag_id)
+
+        return errors["total"]
+
+# pylint: disable=too-many-instance-attributes
+
+
+class ExperimentManager:
+    # ExperimentManager is a Factory function for PerfcapExperiments
+    # PerfcapExperiment and PerfcapFunction classes are instantiated with the ExperimentManager instance injected into their instances
+    # ExperimentManager uses RMQService to talk with the benchmark server.
+    # All communication to the Perfcap Benchmark Server goes through ExperimentManager
+
+    def _setupRMQ(self) -> _RMQService:
+
+        rmqsettings_fpath = os.path.join(pathlib.Path(os.path.abspath(__file__)).parent, "experiment_config\\rmqsettings.json")
+        with open(rmqsettings_fpath) as f:
+            rmq_settings = json.load(f)
+
+        # in case Benchmark is run under multi processing, each process (i.e. one instance of Experiment Manager)
+        # defines a unique routing_key to receive messages from Perfcap Benchmark Server
+        # this routing key is embedded in outgoing messages by RMQService, so that the Perfcap Benchmark Server knows under which
+        # routing key to forward the reply.
+        rmq_settings = _RMQSettings(conn_str=rmq_settings["uri"], exchange_in=rmq_settings["ng_exchange_in"],
+                                    exchange_out=rmq_settings["ng_exchange_out"], routing_key_in=str(uuid_gen()))
+        return _RMQService(rmq_settings)
+
+    def __init__(self, experiment_filename: str, budgets: tp.List[int],
+                 optimizers: tp.List[tp.Union[str, ng.optimization.base.ConfiguredOptimizer]],
+                 seedg: tp.Iterator[tp.Optional[int]] = None) -> None:
+
+        self._rmq_service: _RMQService = None
+        self._current_experiment_name: str = experiment_filename
+        self._experiment_set: bool = False
+        self._no_of_pending_experiments: int = 0
+        self._budgets: tp.List[int] = budgets
+        self._optimizers: tp.List[tp.Union[str, ng.optimization.base.ConfiguredOptimizer]] = optimizers
+        self._seedgen: tp.Iterator[tp.Optional[int]] = seedg
+        self._logger = logging.getLogger("ExperimentManager")
+        self._experiment_cfg: tp.Dict[str, tp.Any] = None
+        self._experiment_id: tp.Union[int, None] = None
+
+        self._load_experiment_file()
+
+    def _load_experiment_file(self) -> None:
+        """
+        Loads an experimentX.json file
+        """
+        experiment_filename = self._current_experiment_name
+        expfpath = os.path.join(pathlib.Path(os.path.abspath(__file__)).parent, "experiment_config", experiment_filename)
+        try:
+            with open(expfpath) as f:
+                self._experiment_cfg = json.load(f)
+        except Exception as ex:
+            self._logger.error("Error while loading %s", experiment_filename)
+            self._logger.exception(ex)
+            raise ex
+
+    def _set_experiment(self) -> None:
+        """
+        Request Perfcap Benchmark Server to setup an experiment (i.e switch to specific dataset)
+        This function is called by the _start_experiment method, at the beginning of an experiment.
+        Subsequent calls to _set_experiment with the same experiment_id are ignored by the Perfcap Benchmark Server
+        Currently, Perfcap Benchmark Server requires setting the experiment once through its life time.
+        Switching to a different experiment (experiment with different experiment_id) after a previous experiment
+        has already been set, is not supported. In this case, consider restarting Perfcap Benchmark Server
+        or start a new Perfcap Benchmark Server instance under different RMQSettings
+        """
+
+        if self._experiment_set:
+            return
+        experiment_filename = self._current_experiment_name
+        self._logger.info("Setting experiment to: %s", experiment_filename)
+
+        self._logger.info("Sending Perfcap bechmark server request to set experiment to %s", experiment_filename)
+        msg = self._experiment_cfg["benchmark_server_args"]
+        experiment_id = self._experiment_cfg["benchmark_server_args"]["experiment_id"]
+        msg.update({"action": "set_experiment"})
+        res = self._rmq_service.request_forced(msg)
+        try:
+            status = Status(res["status"])
+            msg = res["message"]
+
+            if status != Status.OK:
+                self._logger.error("Benchmark server ERROR status: %s", str(status))
+                self._logger.error("Benchmark server ERROR reply: %s", msg)
+                raise Exception("Benchmark server ERROR: Could not set experiment to: {0}".format(experiment_filename))
+
+            self._logger.info("Reply from benchmark server: %s", msg)
+            self._logger.info("Experiment %s set successfully", experiment_filename)
+            self._experiment_id = experiment_id
+            self._experiment_set = True
+        except KeyError as ex:
+            self._logger.error("Error while parsing reply for set experiment from benchmark server")
+            raise ex
+
+    def _register_experiment(self, experiment_tag_id) -> None:
+        """
+        Register experiment to benchmark server in order to facilitate logging.
+        Optimizer evaluation point history logs and meshes in the converged pose are automatically saved by the benchmark server
+        when the experiment is unregistered (i.e at the end of the experiment). Correspondence between nevergrad log and benchmark server
+        can be achived via experiment_tag_id
+
+        This Function is called by PerfcapExperiment class at the beginning of the experiment
+        """
+        self._logger.info("Registering experiment with tag id %s", experiment_tag_id)
+        msg = {
+            "action": "start_experiment",
+            "experiment_tag_id": experiment_tag_id
+        }
+        res = self._rmq_service.request_forced(msg)
+        try:
+            status = Status(res["status"])
+            msg = res["message"]
+
+            if status != Status.OK:
+                self._logger.error("Benchmark server ERROR status: %s", str(status))
+                self._logger.error("Benchmark server ERROR reply: %s", msg)
+                raise Exception("Benchmark server ERROR: Could not register experiment to: {0}".format(experiment_tag_id))
+
+            self._logger.info("Reply from benchmark server: %s", msg)
+            self._logger.info("Experiment %s registered successfully", experiment_tag_id)
+        except KeyError as ex:
+            self._logger.error("Error while parsing reply for register experiment from benchmark server")
+            raise ex
+
+    def _unregister_experiment(self, experiment_tag_id, converged_pose: tp.Dict[int, tp.List[float]]) -> None:
+        """
+        Unregister Experiment, when experiment finishes. This causes benchmark server to flush logs and output meshes
+        for this experiment.
+        This function is called by PerfcapExeriment class at the end of the experiment
+        """
+        self._logger.info("Unregistering experiment with tag id %s", experiment_tag_id)
+        pose_dict = [{"joint_id": jid, "values": vals} for (jid, vals) in converged_pose.items()]
+        msg = {
+            "action": "stop_experiment",
+            "experiment_tag_id": experiment_tag_id,
+            "pose": pose_dict
+        }
+        res = self._rmq_service.request_forced(msg)
+        try:
+            status = Status(res["status"])
+            msg = res["message"]
+
+            if status != Status.OK:
+                self._logger.error("Benchmark server ERROR status: %s", str(status))
+                self._logger.error("Benchmark server ERROR reply: %s", msg)
+                raise Exception("Benchmark server ERROR: Could not unregister experiment: {0}".format(experiment_tag_id))
+
+            self._logger.info("Reply from benchmark server: %s", msg)
+            self._logger.info("Experiment %s unregistered successfully", experiment_tag_id)
+        except KeyError as ex:
+            self._logger.error("Error while parsing reply for unregister experiment from benchmark server")
+            raise ex
+
+    def _start_experiment(self, experiment_tag_id: str):
+        """
+        This function is called by PerfcapExperiment class at the beggining of an experiment run.
+        It requests Perfcap Benchmark Server to open the project dataset corresponding to the current experiment_id
+        and registers the PerfcapExperiment under experiment_tag_id to facilitate logging correspondeces between
+        Perfcap Benchmark Server and nevergrad logs.
+        """
+        #self._logger.info("Start experiment thread_id: %s", threading.current_thread().ident)
+        self._no_of_pending_experiments += 1
+        if self._rmq_service is None:
+            self._rmq_service = self._setupRMQ()
+        self._set_experiment()
+        self._register_experiment(experiment_tag_id)
+
+    def _stop_experiment(self, experiment_tag_id: str, converged_pose: tp.Dict[int, tp.List[float]]):
+        """
+        This will unregister the experiment from Perfcap Benchmark Server, causing any server logging to flush.
+        This function is called by PerfcapExperiment at the end of the experiment run.
+        """
+        self._unregister_experiment(experiment_tag_id, converged_pose)
+        self._no_of_pending_experiments -= 1
+        if (self._rmq_service is not None) and (self._no_of_pending_experiments == 0):
+            print("Stopping RMQ Service")
+            self._rmq_service.stop()
+
+    def _request_function_evaluation(self, pose: tp.Dict[int, tp.List[float]], experiment_tag_id: str) -> tp.Dict[str, float]:
+        """
+        This function will submit a request to the Perfcap Benchmark Server for an objective function evaluation.
+        This function is called by PerfcapFunction to server objective function evaluations
+        """
+        pose_dict = [{"joint_id": jid, "values": vals} for (jid, vals) in pose.items()]
+        msg = {"action": "function_evaluation",
+               "experiment_id": self._experiment_id,
+               "experiment_tag_id": experiment_tag_id,
+               "pose": pose_dict}
+
+        self._logger.debug("Requesting function evaluation")
+        return self._rmq_service.request_forced(msg)
+
+    def experiments(self) -> tp.Iterator[Experiment]:
+        """
+        Factory function that creates PerfcapExperiments based on ExperimentManager's constructor configuration
+        """
+        # pylint: disable=stop-iteration-return
+        for budget in self._budgets:
+            for optim in self._optimizers:
+                yield PerfcapExperiment(self,
+                                        function=PerfcapFunction(self, self._experiment_cfg["ng_function_args"], str(uuid_gen())),
+                                        optimizer=optim, budget=budget, seed=next(self._seedgen))

--- a/nevergrad/benchmark/perfcap/experiment_config/experiment1.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/experiment1.json
@@ -1,0 +1,252 @@
+{
+	"benchmark_server_args" : {
+		"experiment_id": 1,
+		"project_file_path": "./data/projects/Pushups/Pushups.perfproj",
+		"frame_index": 58,
+		"error_weights": {
+			"silhouette": 0.1,
+			"chamfer_total": 1.0,
+			"surface_gradient_error": 0.01,
+			"self_penetration": 1.0,
+			"anthropomorfic_constraints":1.0
+		}
+	},
+	"ng_function_args" : {
+
+		"initial_pose": [
+			{
+				"joint_id": -1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 0,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 2,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 3,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 4,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 5,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 6,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 7,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 8,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 9,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 10,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 11,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 12,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 13,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 14,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 15,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 16,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 17,
+				"values":[0, 0, 0]
+			}
+		],
+		"relative_search_space" : true,
+		"normalize" : false,
+		"variables": [
+			{
+				"joint_id":-1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[0.1,0.1,0.1],
+				"mutable_mutation_variances":[true,true,true],
+				"bounds_min" : [-0.4,-0.4,-0.4],
+				"bounds_max" : [0.4,0.4,0.4]
+
+			},
+			{
+				"joint_id":0,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":2,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":3,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":4,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":5,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":6,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":7,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":8,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":9,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":10,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":11,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":12,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":13,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":14,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			},
+			{
+				"joint_id":15,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":16,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":17,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0,  3.0],
+				"mutable_mutation_variances":[true,  true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			}
+		]
+	}
+}

--- a/nevergrad/benchmark/perfcap/experiment_config/experiment10.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/experiment10.json
@@ -1,0 +1,252 @@
+{
+	"benchmark_server_args" : {
+		"experiment_id": 10,
+		"project_file_path": "./data/projects/Dancing1/Dancing1.perfproj",
+		"frame_index": 68,
+		"error_weights": {
+			"silhouette": 0.1,
+			"chamfer_total": 1.0,
+			"surface_gradient_error": 0.01,
+			"self_penetration": 1.0,
+			"anthropomorfic_constraints":1.0
+		}
+	},
+	"ng_function_args" : {
+
+		"initial_pose": [
+			{
+				"joint_id": -1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 0,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 2,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 3,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 4,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 5,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 6,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 7,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 8,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 9,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 10,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 11,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 12,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 13,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 14,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 15,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 16,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 17,
+				"values":[0, 0, 0]
+			}
+		],
+		"relative_search_space" : true,
+		"normalize" : false,
+		"variables": [
+			{
+				"joint_id":-1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[0.1,0.1,0.1],
+				"mutable_mutation_variances":[true,true,true],
+				"bounds_min" : [-0.4,-0.4,-0.4],
+				"bounds_max" : [0.4,0.4,0.4]
+
+			},
+			{
+				"joint_id":0,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":2,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":3,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":4,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":5,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":6,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":7,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":8,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":9,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":10,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":11,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":12,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":13,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":14,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			},
+			{
+				"joint_id":15,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":16,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":17,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			}
+		]
+	}
+}

--- a/nevergrad/benchmark/perfcap/experiment_config/experiment11.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/experiment11.json
@@ -1,0 +1,252 @@
+{
+	"benchmark_server_args" : {
+		"experiment_id": 11,
+		"project_file_path": "./data/projects/Stretching/Stretching.perfproj",
+		"frame_index": 358,
+		"error_weights": {
+			"silhouette": 0.1,
+			"chamfer_total": 1.0,
+			"surface_gradient_error": 0.01,
+			"self_penetration": 1.0,
+			"anthropomorfic_constraints":1.0
+		}
+	},
+	"ng_function_args" : {
+
+		"initial_pose": [
+			{
+				"joint_id": -1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 0,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 2,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 3,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 4,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 5,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 6,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 7,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 8,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 9,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 10,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 11,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 12,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 13,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 14,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 15,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 16,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 17,
+				"values":[0, 0, 0]
+			}
+		],
+		"relative_search_space" : true,
+		"normalize" : false,
+		"variables": [
+			{
+				"joint_id":-1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[0.1,0.1,0.1],
+				"mutable_mutation_variances":[true,true,true],
+				"bounds_min" : [-0.4,-0.4,-0.4],
+				"bounds_max" : [0.4,0.4,0.4]
+
+			},
+			{
+				"joint_id":0,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":2,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":3,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":4,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":5,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":6,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":7,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":8,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":9,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":10,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":11,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":12,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":13,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":14,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			},
+			{
+				"joint_id":15,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":16,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":17,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			}
+		]
+	}
+}

--- a/nevergrad/benchmark/perfcap/experiment_config/experiment2.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/experiment2.json
@@ -1,0 +1,252 @@
+{
+	"benchmark_server_args" : {
+		"experiment_id": 2,
+		"project_file_path": "./data/projects/Ballet/Ballet.perfproj",
+		"frame_index": 286,
+		"error_weights": {
+			"silhouette": 0.1,
+			"chamfer_total": 1.0,
+			"surface_gradient_error": 0.01,
+			"self_penetration": 1.0,
+			"anthropomorfic_constraints":1.0
+		}
+	},
+	"ng_function_args" : {
+
+		"initial_pose": [
+			{
+				"joint_id": -1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 0,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 2,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 3,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 4,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 5,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 6,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 7,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 8,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 9,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 10,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 11,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 12,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 13,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 14,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 15,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 16,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 17,
+				"values":[0, 0, 0]
+			}
+		],
+		"relative_search_space" : true,
+		"normalize" : false,
+		"variables": [
+			{
+				"joint_id":-1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[0.1,0.1,0.1],
+				"mutable_mutation_variances":[true,true,true],
+				"bounds_min" : [-0.4,-0.4,-0.4],
+				"bounds_max" : [0.4,0.4,0.4]
+
+			},
+			{
+				"joint_id":0,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":2,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":3,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":4,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":5,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":6,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":7,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":8,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":9,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":10,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":11,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":12,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":13,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":14,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			},
+			{
+				"joint_id":15,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":16,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":17,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			}
+		]
+	}
+}

--- a/nevergrad/benchmark/perfcap/experiment_config/experiment3.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/experiment3.json
@@ -1,0 +1,252 @@
+{
+	"benchmark_server_args" : {
+		"experiment_id": 3,
+		"project_file_path": "./data/projects/Calisthenics/Calisthenics.perfproj",
+		"frame_index": 34,
+		"error_weights": {
+			"silhouette": 0.1,
+			"chamfer_total": 1.0,
+			"surface_gradient_error": 0.01,
+			"self_penetration": 1.0,
+			"anthropomorfic_constraints":1.0
+		}
+	},
+	"ng_function_args" : {
+
+		"initial_pose": [
+			{
+				"joint_id": -1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 0,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 2,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 3,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 4,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 5,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 6,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 7,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 8,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 9,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 10,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 11,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 12,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 13,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 14,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 15,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 16,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 17,
+				"values":[0, 0, 0]
+			}
+		],
+		"relative_search_space" : true,
+		"normalize" : false,
+		"variables": [
+			{
+				"joint_id":-1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[0.1,0.1,0.1],
+				"mutable_mutation_variances":[true,true,true],
+				"bounds_min" : [-0.4,-0.4,-0.4],
+				"bounds_max" : [0.4,0.4,0.4]
+
+			},
+			{
+				"joint_id":0,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":2,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":3,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":4,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":5,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":6,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":7,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":8,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":9,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":10,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":11,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":12,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":13,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":14,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			},
+			{
+				"joint_id":15,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":16,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":17,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			}
+		]
+	}
+}

--- a/nevergrad/benchmark/perfcap/experiment_config/experiment4.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/experiment4.json
@@ -1,0 +1,252 @@
+{
+	"benchmark_server_args" : {
+		"experiment_id": 4,
+		"project_file_path": "./data/projects/Boxing/Boxing.perfproj",
+		"frame_index": 302,
+		"error_weights": {
+			"silhouette": 0.1,
+			"chamfer_total": 1.0,
+			"surface_gradient_error": 0.01,
+			"self_penetration": 1.0,
+			"anthropomorfic_constraints":1.0
+		}
+	},
+	"ng_function_args" : {
+
+		"initial_pose": [
+			{
+				"joint_id": -1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 0,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 2,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 3,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 4,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 5,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 6,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 7,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 8,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 9,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 10,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 11,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 12,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 13,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 14,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 15,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 16,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 17,
+				"values":[0, 0, 0]
+			}
+		],
+		"relative_search_space" : true,
+		"normalize" : false,
+		"variables": [
+			{
+				"joint_id":-1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[0.1,0.1,0.1],
+				"mutable_mutation_variances":[true,true,true],
+				"bounds_min" : [-0.4,-0.4,-0.4],
+				"bounds_max" : [0.4,0.4,0.4]
+
+			},
+			{
+				"joint_id":0,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":2,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":3,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":4,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":5,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":6,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":7,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":8,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":9,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":10,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":11,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":12,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":13,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":14,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			},
+			{
+				"joint_id":15,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":16,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":17,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			}
+		]
+	}
+}

--- a/nevergrad/benchmark/perfcap/experiment_config/experiment5.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/experiment5.json
@@ -1,0 +1,252 @@
+{
+	"benchmark_server_args" : {
+		"experiment_id": 5,
+		"project_file_path": "./data/projects/Yoga1/Yoga1.perfproj",
+		"frame_index": 1050,
+		"error_weights": {
+			"silhouette": 0.1,
+			"chamfer_total": 1.0,
+			"surface_gradient_error": 0.01,
+			"self_penetration": 1.0,
+			"anthropomorfic_constraints":1.0
+		}
+	},
+	"ng_function_args" : {
+
+		"initial_pose": [
+			{
+				"joint_id": -1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 0,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 2,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 3,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 4,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 5,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 6,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 7,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 8,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 9,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 10,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 11,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 12,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 13,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 14,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 15,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 16,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 17,
+				"values":[0, 0, 0]
+			}
+		],
+		"relative_search_space" : true,
+		"normalize" : false,
+		"variables": [
+			{
+				"joint_id":-1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[0.1,0.1,0.1],
+				"mutable_mutation_variances":[true,true,true],
+				"bounds_min" : [-0.4,-0.4,-0.4],
+				"bounds_max" : [0.4,0.4,0.4]
+
+			},
+			{
+				"joint_id":0,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":2,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":3,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":4,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":5,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":6,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":7,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":8,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":9,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":10,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":11,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":12,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":13,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":14,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			},
+			{
+				"joint_id":15,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":16,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":17,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			}
+		]
+	}
+}

--- a/nevergrad/benchmark/perfcap/experiment_config/experiment6.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/experiment6.json
@@ -1,0 +1,252 @@
+{
+	"benchmark_server_args" : {
+		"experiment_id": 6,
+		"project_file_path": "./data/projects/Yoga2/Yoga2.perfproj",
+		"frame_index": 162,
+		"error_weights": {
+			"silhouette": 0.1,
+			"chamfer_total": 1.0,
+			"surface_gradient_error": 0.01,
+			"self_penetration": 1.0,
+			"anthropomorfic_constraints":1.0
+		}
+	},
+	"ng_function_args" : {
+
+		"initial_pose": [
+			{
+				"joint_id": -1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 0,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 2,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 3,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 4,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 5,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 6,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 7,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 8,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 9,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 10,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 11,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 12,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 13,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 14,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 15,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 16,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 17,
+				"values":[0, 0, 0]
+			}
+		],
+		"relative_search_space" : true,
+		"normalize" : false,
+		"variables": [
+			{
+				"joint_id":-1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[0.1,0.1,0.1],
+				"mutable_mutation_variances":[true,true,true],
+				"bounds_min" : [-0.4,-0.4,-0.4],
+				"bounds_max" : [0.4,0.4,0.4]
+
+			},
+			{
+				"joint_id":0,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":2,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":3,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":4,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":5,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":6,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":7,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":8,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":9,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":10,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":11,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":12,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":13,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":14,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			},
+			{
+				"joint_id":15,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":16,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":17,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			}
+		]
+	}
+}

--- a/nevergrad/benchmark/perfcap/experiment_config/experiment7.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/experiment7.json
@@ -1,0 +1,252 @@
+{
+	"benchmark_server_args" : {
+		"experiment_id": 7,
+		"project_file_path": "./data/projects/Jumpingjacks/Jumpingjacks.perfproj",
+		"frame_index": 47,
+		"error_weights": {
+			"silhouette": 0.1,
+			"chamfer_total": 1.0,
+			"surface_gradient_error": 0.01,
+			"self_penetration": 1.0,
+			"anthropomorfic_constraints":1.0
+		}
+	},
+	"ng_function_args" : {
+
+		"initial_pose": [
+			{
+				"joint_id": -1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 0,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 2,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 3,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 4,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 5,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 6,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 7,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 8,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 9,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 10,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 11,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 12,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 13,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 14,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 15,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 16,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 17,
+				"values":[0, 0, 0]
+			}
+		],
+		"relative_search_space" : true,
+		"normalize" : false,
+		"variables": [
+			{
+				"joint_id":-1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[0.1,0.1,0.1],
+				"mutable_mutation_variances":[true,true,true],
+				"bounds_min" : [-0.4,-0.4,-0.4],
+				"bounds_max" : [0.4,0.4,0.4]
+
+			},
+			{
+				"joint_id":0,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":2,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":3,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":4,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":5,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":6,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":7,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":8,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":9,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":10,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":11,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":12,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":13,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":14,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			},
+			{
+				"joint_id":15,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":16,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":17,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			}
+		]
+	}
+}

--- a/nevergrad/benchmark/perfcap/experiment_config/experiment8.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/experiment8.json
@@ -1,0 +1,252 @@
+{
+	"benchmark_server_args" : {
+		"experiment_id": 8,
+		"project_file_path": "./data/projects/Football/Football.perfproj",
+		"frame_index": 584,
+		"error_weights": {
+			"silhouette": 0.1,
+			"chamfer_total": 1.0,
+			"surface_gradient_error": 0.01,
+			"self_penetration": 1.0,
+			"anthropomorfic_constraints":1.0
+		}
+	},
+	"ng_function_args" : {
+
+		"initial_pose": [
+			{
+				"joint_id": -1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 0,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 2,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 3,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 4,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 5,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 6,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 7,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 8,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 9,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 10,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 11,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 12,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 13,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 14,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 15,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 16,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 17,
+				"values":[0, 0, 0]
+			}
+		],
+		"relative_search_space" : true,
+		"normalize" : false,
+		"variables": [
+			{
+				"joint_id":-1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[0.1,0.1,0.1],
+				"mutable_mutation_variances":[true,true,true],
+				"bounds_min" : [-0.4,-0.4,-0.4],
+				"bounds_max" : [0.4,0.4,0.4]
+
+			},
+			{
+				"joint_id":0,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":2,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":3,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":4,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":5,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":6,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":7,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":8,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":9,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":10,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":11,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":12,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":13,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":14,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			},
+			{
+				"joint_id":15,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":16,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":17,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			}
+		]
+	}
+}

--- a/nevergrad/benchmark/perfcap/experiment_config/experiment9.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/experiment9.json
@@ -1,0 +1,252 @@
+{
+	"benchmark_server_args" : {
+		"experiment_id": 9,
+		"project_file_path": "./data/projects/Dancing2/Dancing2.perfproj",
+		"frame_index": 379,
+		"error_weights": {
+			"silhouette": 0.1,
+			"chamfer_total": 1.0,
+			"surface_gradient_error": 0.01,
+			"self_penetration": 1.0,
+			"anthropomorfic_constraints":1.0
+		}
+	},
+	"ng_function_args" : {
+
+		"initial_pose": [
+			{
+				"joint_id": -1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 0,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 1,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 2,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 3,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 4,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 5,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 6,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 7,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 8,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 9,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 10,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 11,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 12,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 13,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 14,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 15,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 16,
+				"values":[0, 0, 0]
+			},
+			{
+				"joint_id": 17,
+				"values":[0, 0, 0]
+			}
+		],
+		"relative_search_space" : true,
+		"normalize" : false,
+		"variables": [
+			{
+				"joint_id":-1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[0.1,0.1,0.1],
+				"mutable_mutation_variances":[true,true,true],
+				"bounds_min" : [-0.4,-0.4,-0.4],
+				"bounds_max" : [0.4,0.4,0.4]
+
+			},
+			{
+				"joint_id":0,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":1,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":2,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":3,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":4,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":5,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":6,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":7,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":8,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":9,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":10,
+				"DOFs" : [true, false, false],
+				"mutation_variances":[3.0],
+				"mutable_mutation_variances":[true],
+				"bounds_min" : [-15.0],
+				"bounds_max" : [15.0]
+			},
+			{
+				"joint_id":11,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":12,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":13,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":14,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			},
+			{
+				"joint_id":15,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":16,
+				"DOFs" : [true, true, true],
+				"mutation_variances":[3.0, 3.0, 3.0],
+				"mutable_mutation_variances":[true, true, true],
+				"bounds_min" : [-15.0, -15.0, -15.0],
+				"bounds_max" : [15.0, 15.0, 15.0]
+			},
+			{
+				"joint_id":17,
+				"DOFs" : [true, false, true],
+				"mutation_variances":[3.0, 3.0],
+				"mutable_mutation_variances":[true, true],
+				"bounds_min" : [-15.0, -15.0],
+				"bounds_max" : [15.0, 15.0]
+			}
+		]
+	}
+}

--- a/nevergrad/benchmark/perfcap/experiment_config/rmqsettings.json
+++ b/nevergrad/benchmark/perfcap/experiment_config/rmqsettings.json
@@ -1,0 +1,5 @@
+{
+    "uri": "amqp://user:pass@127.0.0.1:5672",
+    "ng_exchange_in": "ng-bench.in",
+    "ng_exchange_out": "ng-bench.out"
+}

--- a/nevergrad/benchmark/perfcap/experiments.py
+++ b/nevergrad/benchmark/perfcap/experiments.py
@@ -1,0 +1,13 @@
+#################################################################
+# Author: Alex Doumanoglou (al3x.doum@gmail.com / aldoum@iti.gr)
+# Information Technologies Institute - Visual Computing Lab (https://vcl.iti.gr)
+# 30 Sept 2020
+#################################################################
+import typing as tp
+from nevergrad.benchmark.perfcap.core import ExperimentManager
+from nevergrad.benchmark.experiments import Experiment
+
+def perfcap_experiment(experiment_filename: str, seedg: tp.Iterator[tp.Optional[int]]) -> tp.Iterator[Experiment]:
+    return ExperimentManager(experiment_filename, [2000, 4000, 7000], ["Shiwa", "RandomSearch",
+                                                                       "RealSpacePSO", "Powell", "DiscreteOnePlusOne",
+                                                                       "CMA", "NGO", "TBPSA", "chainCMAPowell", "DE"], seedg).experiments()

--- a/nevergrad/benchmark/perfcap/rmqservice.py
+++ b/nevergrad/benchmark/perfcap/rmqservice.py
@@ -1,0 +1,208 @@
+#################################################################
+# Author: Alex Doumanoglou (al3x.doum@gmail.com / aldoum@iti.gr)
+# Information Technologies Institute - Visual Computing Lab (https://vcl.iti.gr)
+# 30 Sept 2020
+#################################################################
+
+import asyncio
+import typing as tp
+import threading
+import logging
+import json
+from uuid import uuid4 as uuid_gen
+from concurrent.futures import Future
+import aio_pika
+
+
+class RMQSettings:
+    def __init__(self, conn_str: str, exchange_in: str, exchange_out: str, routing_key_in: str = None):
+        self.connection_string: str = conn_str
+        self.exchange_in: str = exchange_in
+        self.exchange_out: str = exchange_out
+        self.routing_key_in: str = routing_key_in
+
+
+class RMQService:
+    """
+    RabbitMQ Client, based on asyncio and aio_pika
+    This network module is responsible for low-level communication with the Perfcap Benchmark Server
+    This is a threaded implemenation. Network I/O takes place in a background thread
+    All requests to the benchmark server happen through the request method, which appears to the caller as a blocking call until
+    the request has been served by the Perfcap Benchmark Server and a reply has been received.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, rmq_settings: RMQSettings, do_rmq_exch_cleanup: bool = False):
+
+        self._rmq_settings = rmq_settings
+        self._event_loop: asyncio.AbstractEventLoop = None
+        self._thread: threading.Thread = None
+        self._request_futures: tp.Dict[str, Future] = {}
+        self._consumer_tag: aio_pika.queue.ConsumerTag = None
+
+        self._connection: aio_pika.ConnectionType = None
+        self._channel: aio_pika.Channel = None
+        self._exch_in: aio_pika.Exchange = None
+        self._exch_out: aio_pika.Exchange = None
+        self._queue_in: aio_pika.Queue = None
+        self._pending_futures: tp.Set[Future] = set()
+        self._do_rmq_exch_cleanup: bool = do_rmq_exch_cleanup
+        self._logger = logging.getLogger("RMQService")
+
+    def _shutdown_futures(self):
+        """
+        Future clean up on shutdown
+        """
+        for (_, ft) in self._request_futures.items():
+            ft.set_exception(Exception("RMQService Future aborted."))
+        for ft in self._pending_futures:
+            ft.set_exception(Exception("RMQService Future aborted."))
+        self._request_futures.clear()
+        self._pending_futures.clear()
+
+    async def _process_message(self, message: aio_pika.IncomingMessage) -> tp.Dict[str, tp.Any]:
+        """
+        Processes incoming message from RMQ
+        """
+        async with message.process():
+            json_msg = json.loads(message.body)
+            tid = json_msg["reply_info"]["transaction_id"]          # get transaction_id from the reply message
+            ft = self._request_futures.pop(tid, None)               # obtain future from dictionary
+            if ft is not None:
+                ft.set_result(json_msg["args"])                     # set future result from received message
+
+    async def _setup(self, loop: asyncio.AbstractEventLoop):
+        """
+        Connect to RMQ Server and setup Exchanges/Queues.
+        """
+        try:
+
+            self._connection = await aio_pika.connect(self._rmq_settings.connection_string, loop=loop)
+            self._channel = await self._connection.channel()
+            self._exch_in = await self._channel.declare_exchange(self._rmq_settings.exchange_in, type=aio_pika.ExchangeType.FANOUT,
+                                                                 auto_delete=False)
+            self._exch_out = await self._channel.declare_exchange(self._rmq_settings.exchange_out, type=aio_pika.ExchangeType.FANOUT,
+                                                                  auto_delete=True)
+
+            self._queue_in = await self._channel.declare_queue("", auto_delete=True)
+
+            if self._rmq_settings.routing_key_in is None:
+                await self._queue_in.bind(self._exch_in)
+            else:
+                await self._queue_in.bind(self._exch_in, self._rmq_settings.routing_key_in)
+            self._consumer_tag = await self._queue_in.consume(self._process_message)
+        except aio_pika.AMQPException as ex:
+            self._logger.error("RMQService setup failed... shutting down.")
+            self._logger.exception(ex)
+            self._event_loop.stop()
+
+    async def _shutdown(self):
+        """
+        Clean up function when RMQService is stopped
+        """
+        if self._queue_in is not None:
+            await self._queue_in.cancel(self._consumer_tag)
+            await self._queue_in.delete()
+
+        if self._do_rmq_exch_cleanup:
+            if self._exch_in is not None:
+                await self._exch_in.delete()
+            if self._exch_out is not None:
+                await self._exch_out.delete()
+
+        if self._channel is not None:
+            await self._channel.close()
+        if self._connection is not None:
+            await self._connection.close()
+
+        self._queue_in = None
+        self._exch_in = None
+        self._exch_out = None
+        self._channel = None
+        self._connection = None
+
+        self._shutdown_futures()
+
+    def _main(self):
+        """
+        Main method of background thread
+        """
+        asyncio.set_event_loop(self._event_loop)
+        self._event_loop.run_forever()
+        self._event_loop.run_until_complete(self._shutdown())
+        self._event_loop.close()
+
+    async def _request(self, msg: tp.Dict[str, tp.Any], ft: Future):
+        """
+        Core function to submit requests to Perfcap Benchmark Server through RMQ.
+        """
+        self._pending_futures.remove(ft)
+        tid = str(uuid_gen())               # generate a transaction_id (i.e. request id)
+        self._request_futures[tid] = ft     # add future to _request_future dictionary under transaction_id key
+        request_info: tp.Dict[str, str] = {
+            # embed listener's routing key to the message. benchmark server will reply to this request in
+            # the routing_key specified in reply_id
+            "reply_id": self._rmq_settings.routing_key_in if self._rmq_settings.routing_key_in is not None else "",
+            # mark transaction with id. this will help identify the reply of the server.
+            # The server always embeds transaction_id to its reply message.
+            "transaction_id": tid
+        }
+        fmsg = {}
+        fmsg["request_info"] = request_info
+        fmsg["args"] = msg
+        await self._exch_out.publish(aio_pika.Message(bytes(json.dumps(fmsg), encoding='utf-8')), routing_key="")
+
+    def _request_safe(self, msg: tp.Dict[str, tp.Any], ft: Future):
+        self._pending_futures.add(ft)
+        if self._exch_out is not None:  # if nevegrad output exchange has been created enqueue request
+            asyncio.create_task(self._request(msg, ft))
+        else:
+            # exchange is not ready yet (we are still connecting to RMQ Server). Requeue, for later
+            self._event_loop.call_later(0.3, self._request_safe, msg, ft)
+
+    def request(self, msg: tp.Dict[str, tp.Any]) -> tp.Union[None, tp.Dict[str, tp.Any]]:
+        """
+        Submit a request to the Perfcap Benchmark Server.
+        This is a blocking call returning the result replied from the server.
+        You must first call run() for this method to have any effect.
+        """
+        if self._thread is not None:
+            ft = Future()
+            self._event_loop.call_soon_threadsafe(self._request_safe, msg, ft)
+            return ft.result()
+        return None
+
+    def request_forced(self, msg: tp.Dict[str, tp.Any]) -> tp.Dict[str, tp.Any]:
+        """
+        Submit a request to the Perfcap Benchmark Server.
+        This is a blocking call returning the result replied from the server
+        In case the RMQService is not in running state, it is silently started
+        """
+        if self._thread is None:
+            self.run()
+
+        ft = Future()
+        self._event_loop.call_soon_threadsafe(self._request_safe, msg, ft)
+        return ft.result()
+
+    def run(self):
+        """
+        This method initiates network connection to the RMQ Server in a background thread.
+        """
+        if self._thread is not None:
+            return
+
+        self._event_loop = asyncio.new_event_loop()
+        self._event_loop.call_soon_threadsafe(lambda: asyncio.create_task(self._setup(self._event_loop)))
+        self._thread = threading.Thread(target=self._main)
+        self._thread.start()
+
+    def stop(self):
+        """
+        Call this method to disconnect from RMQServer and stop the background thread.
+        """
+        if (self._event_loop is not None) and (self._thread is not None):
+            self._event_loop.call_soon_threadsafe(self._event_loop.stop)
+            self._thread.join()
+            self._thread = None
+            self._event_loop = None

--- a/nevergrad/benchmark/xpbase.py
+++ b/nevergrad/benchmark/xpbase.py
@@ -181,6 +181,7 @@ class Experiment:
         except fbase.ExperimentFunctionCopyError as c_e:
             raise c_e
         except Exception as e:  # pylint: disable=broad-except
+                                # pyline: disable=duplicate-code
             # print the case and the traceback
             self.result["error"] = e.__class__.__name__
             print(f"Error when applying {self}:", file=sys.stderr)
@@ -196,6 +197,8 @@ class Experiment:
         # make a final evaluation with oracle (no noise, but function may still be stochastic)
         assert self.recommendation is not None
         reco = self.recommendation
+        self.result[r"{recommendation}"] = reco     # log recommendation,
+        # but exclude from fight plots by encapsulating its name inside "{ }"
         assert self._optimizer is not None
         if self._optimizer._hypervolume_pareto is None:
             # ExperimentFunction can directly override this if need be


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context 

This pull request regards the addition of a new benchmark to the nevergrad platform for the real-world noisy problem of 3D Human Performance Capture via fitting an animatable template 3D mesh to post-processed sensed 3D data.

The dataset consists of 3D captures of 11 human performances, recorded via the Multi-View Volumetric Capture System of [[1]]. For the purposes of this benchmark and for each performance, a 3D animatable template mesh has been created along with the selection of one individual target frame. The benchmark aims to assess the performance of nevergrad optimizers to the task of fitting the animatable template mesh (via its animation parameters) to the sensed 3D data of the selected performance’s target frame.

To realize the concept, along with this pull request, we release Windows binaries of a Performance Capture Benchmark Server (Perfcap benchmark server) which is able to serve Objective Function evaluations for arbitrary template mesh animation parameter values for each one of the designed experiments. To the nevergrad side, we implemented a python client to this benchmark server, which acts as an Objective Function proxy for every benchmarked optimizer.

I think this pull request is compatible with the latest version of nevegrad-master and benchmarking has been integrated natively, respecting nevergrad interfaces.
This code, mostly, contains newly added code compatible with the existing one. A small exception is that we added logging of the optimizer's recommendation value to the nevergrad logs as well as a naive mechanism to exclude fields from fight plots based on a naming convention.

While the current implementation supports single objective optimization, a future implementation of the python client may be able to support multi-objective optimization as well, without the need for updated binaries for the benchmark server.

A detailed documentation of this work (which will be continuously updated until our upcoming paper's submission) can be found in https://alexd314.github.io/nevergrad/.
A draft pre-liminary version of our paper can be found in https://drive.google.com/drive/folders/1vtCmmnM4BT-nuqpBMG3I2vZqibHcGWID?usp=sharing
Further, documentation of this work will be submited to GECCO 2021 for the purposes of the Open Optimization Competition 2020.

[1]: https://github.com/VCL3D/VolumetricCapture

## Things to check

Modification to existing code-base:
- `nevergrad/benchmark/frozenexperiments.py` (benchmark experiment registration)
- `nevergrad/benchmark/xpbase.py` (Added recommendation value logging in benchmark experiment under "{recommendation}" key)
- `nevergrad/benchmark/plotting.py` (Modified plotting.py to exclude description fields contained in "{}" from fight plots (Currently Performance Capture Benchmark adds an {experiment_tag_id} value to the description of the Experiment)).
Newly added code:
- `nevergrad/benchmark/perfcap/*`

For this benchmark the objective function, can be implicitly parameterized via json files found in `nevegrad/benchmark/perfcap/experiment_configuration`.

RabbitMQ connection details (for communication with the benchmark server) are currently being read from `rmqsettings.json` found in the `experiment_configuration` folder, since I did not want to introduce changes to the benchmark interface.

## How Has This Been Tested (if it applies)

We have tested the submitted code by following the steps described in the run section of https://alexd314.github.io/nevergrad/.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [X] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [ ] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
