### PR TITLE
Add leaderboard to all Mujoco pbs

### DIFF
--- a/nevergrad/functions/control/core.py
+++ b/nevergrad/functions/control/core.py
@@ -68,6 +68,14 @@ class BaseFunction(ExperimentFunction):
     @property
     def policy_dim(self):
         raise NotImplementedError
+        
+    # pylint: disable=arguments-differ
+    def evaluation_function(self, x: np.ndarray) -> float:  # type: ignore
+        # pylint: disable=not-callable
+        loss = self.function(x)
+        assert isinstance(loss, float)
+        base.update_leaderboard(f'{self.name},{self.parametrization.dimension}', loss, x, verbose=True)
+        return loss
 
 
 

--- a/nevergrad/functions/control/core.py
+++ b/nevergrad/functions/control/core.py
@@ -11,6 +11,7 @@ import numpy as np
 import typing as tp
 from nevergrad.parametrization import parameter as p
 from ..base import ExperimentFunction
+from .. import base
 from .mujoco import GenericMujocoEnv
 
 class BaseFunction(ExperimentFunction):
@@ -74,7 +75,7 @@ class BaseFunction(ExperimentFunction):
         # pylint: disable=not-callable
         loss = self.function(x)
         assert isinstance(loss, float)
-        base.update_leaderboard(f'{self.name},{self.parametrization.dimension}', loss, x, verbose=True)
+        base.update_leaderboard(f'{self.env_name},{self.parametrization.dimension}', loss, x, verbose=True)
         return loss
 
 


### PR DESCRIPTION
This PR adds the Mujoco environments in the leaderboard.
Maybe we should do more than that: check that the value is preserved in the unit test (i.e. at least -4000 for humanoid, etc).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
