### PR TITLE
NGOpt should point to NGOpt8

### DIFF
--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -2124,5 +2124,5 @@ class NGOpt8(NGOpt4):
 
 
 @registry.register
-class NGOpt(NGOpt4):
+class NGOpt(NGOpt8):
     pass


### PR DESCRIPTION
https://github.com/facebookresearch/nevergrad/issues/901 correctly points out a case in which NGOpt performs poorly.
The proposed NGOpt8 does not fail here. Therefore, let us validate switching to NGOpt --> NGOpt8 instead of NGOpt --> NGOpt4.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Issue 901 pointed out by @knoam rightly shows that NGOpt (pointing to NGOpt4) was failing in an easy case.
NGOpt8 looks much better. We switch to NGOpt4.

## How Has This Been Tested (if it applies)

https://github.com/facebookresearch/nevergrad/issues/901

I do not consider the issue as completely solved: it is possible to do better.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
