### PR TITLE
Remove IOH from benchmark install and lazy import it

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,4 +72,5 @@ html_static_path = []
 # -- Other --
 linkcheck_ignore = [r'https://gecco-2020.sigevo.org/*',
                     'windows.html',
+                    "https://iohprofiler.liacs.nl/",  # server error: bad gateway
                     r'https://arxiv.org/abs/*']  # Transient certificate error :(

--- a/nevergrad/benchmark/experiments.py
+++ b/nevergrad/benchmark/experiments.py
@@ -5,7 +5,6 @@
 
 import os
 import warnings
-import logging
 import typing as tp
 import itertools
 import numpy as np
@@ -44,7 +43,9 @@ from . import frozenexperiments  # noqa # pylint: disable=unused-import
 # fmt: off
 
 
-logger = logging.Logger(__file__)
+class MissingBenchmarkPackageError(ModuleNotFoundError):
+    pass
+
 
 default_optims: tp.Optional[tp.List[str]] = None  # ["NGO10", "CMA", "Shiwa"]
 
@@ -1354,8 +1355,7 @@ def pbo_suite(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
                 try:
                     func = iohprofiler.PBOFunction(fid, iid, dim)
                 except ModuleNotFoundError:
-                    logger.warning("IOHexperimenter needs to be installed")
-                    return
+                    raise MissingBenchmarkPackageError("IOHexperimenter needs to be installed")
                 for optim in ["DiscreteOnePlusOne", "Shiwa", "CMA", "PSO", "TwoPointsDE", "DE", "OnePlusOne", "AdaptiveDiscreteOnePlusOne",
                               "CMandAS2", "PortfolioDiscreteOnePlusOne", "DoubleFastGADiscreteOnePlusOne", "MultiDiscrete", "cGA", dde]:
                     for nw in [1, 10]:

--- a/nevergrad/benchmark/experiments.py
+++ b/nevergrad/benchmark/experiments.py
@@ -1353,7 +1353,7 @@ def pbo_suite(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
             for iid in range(1, 5):
                 try:
                     func = iohprofiler.PBOFunction(fid, iid, dim)
-                except AttributeError:
+                except ModuleNotFoundError:
                     logger.warning("IOHexperimenter needs to be installed")
                     return
                 for optim in ["DiscreteOnePlusOne", "Shiwa", "CMA", "PSO", "TwoPointsDE", "DE", "OnePlusOne", "AdaptiveDiscreteOnePlusOne",

--- a/nevergrad/benchmark/test_experiments.py
+++ b/nevergrad/benchmark/test_experiments.py
@@ -7,6 +7,7 @@ import inspect
 import itertools
 import typing as tp
 from pathlib import Path
+from unittest import SkipTest
 import pytest
 import numpy as np
 from nevergrad.optimization import registry as optregistry
@@ -24,9 +25,7 @@ from . import optgroups
 def test_experiments_registry(name: str, maker: tp.Callable[[], tp.Iterator[experiments.Experiment]]) -> None:
     with datasets.mocked_data():  # mock mlda data that should be downloaded
         check_maker(maker)  # this is to extract the function for reuse if other external packages need it
-    if name not in {"realworld_oneshot", "mlda", "mldaas", "realworld", "rocket", "mldakmeans", "control_problem"} and \
-        'mltuning' not in name and \
-        'keras_tuning' not in name:
+    if name not in ["rocket", "control_problem"] and not any(x in name for x in ["tuning", "mlda", "realworld"]):
         check_seedable(maker, "mltuning" in name)  # this is a basic test on first elements, do not fully rely on it
 
 
@@ -54,7 +53,10 @@ def test_groups_registry(name: str, recorder: tp.Dict[str, tp.List[optgroups.Opt
 def check_maker(maker: tp.Callable[[], tp.Iterator[experiments.Experiment]]) -> None:
     generators = [maker() for _ in range(2)]
     # check 1 sample
-    sample = next(maker())
+    try:
+        sample = next(maker())
+    except experiments.MissingBenchmarkPackageError as e:
+        raise SkipTest("Skipping because of missing package") from e
     assert isinstance(sample, experiments.Experiment)
     # check names, coherence and non-randomness
     for k, (elem1, elem2) in enumerate(itertools.zip_longest(*generators)):

--- a/nevergrad/functions/iohprofiler/__init__.py
+++ b/nevergrad/functions/iohprofiler/__init__.py
@@ -1,2 +1,5 @@
-from .core import PBOFunction as PBOFunction
-from .core import WModelFunction as WModelFunction
+try:
+    from .core import PBOFunction as PBOFunction
+    from .core import WModelFunction as WModelFunction
+except ImportError:
+    pass

--- a/nevergrad/functions/iohprofiler/__init__.py
+++ b/nevergrad/functions/iohprofiler/__init__.py
@@ -1,5 +1,5 @@
 try:
     from .core import PBOFunction as PBOFunction
     from .core import WModelFunction as WModelFunction
-except ImportError:
+except ModuleNotFoundError:
     pass

--- a/nevergrad/functions/iohprofiler/__init__.py
+++ b/nevergrad/functions/iohprofiler/__init__.py
@@ -1,5 +1,2 @@
-try:
-    from .core import PBOFunction as PBOFunction
-    from .core import WModelFunction as WModelFunction
-except ModuleNotFoundError:
-    pass
+from .core import PBOFunction as PBOFunction
+from .core import WModelFunction as WModelFunction

--- a/nevergrad/functions/iohprofiler/core.py
+++ b/nevergrad/functions/iohprofiler/core.py
@@ -1,7 +1,7 @@
 import numpy as np
-from IOHexperimenter import IOH_function, W_model_function
 import nevergrad as ng
 from .. import base
+# pylint: disable=import-outside-toplevel
 
 
 class PBOFunction(base.ExperimentFunction):
@@ -34,6 +34,7 @@ class PBOFunction(base.ExperimentFunction):
     """
 
     def __init__(self, fid: int = 1, iid: int = 0, dim: int = 16, instrumentation: str = "Softmax") -> None:
+        from IOHexperimenter import IOH_function  # lazy import in case it is not installed
         if fid in [21, 23]:
             assert np.sqrt(dim).is_integer(), "Dimension needs to be a perfect square for the selected problem"
         self.f_internal = IOH_function(fid=fid, dim=dim, iid=iid, suite="PBO")
@@ -100,11 +101,11 @@ class WModelFunction(base.ExperimentFunction):
         ruggedness: int = 0,
         instrumentation: str = "Softmax"
     ) -> None:
+        from IOHexperimenter import W_model_function  # lazy import in case it is not installed
         assert epistasis <= dim, "Epistasis has to be less or equal to than dimension"
         assert neutrality <= dim, "Neutrality has to be less than or equal to dimension"
         assert ruggedness <= dim ** 2, "Ruggedness has to be less than or equal to dimension squared"
         assert 0 <= dummy <= 1, "Dummy variable fraction has to be in [0,1]"
-
         self.f_internal = W_model_function(base_function=base_function, iid=iid, dim=dim, dummy=dummy, epistasis=epistasis,
                                            neutrality=neutrality, ruggedness=ruggedness)
         assert instrumentation in ["Softmax", "Ordered"], "The only valid options for 'instrumentation' are 'Softmax' and 'Unordered'"

--- a/nevergrad/functions/iohprofiler/test_core.py
+++ b/nevergrad/functions/iohprofiler/test_core.py
@@ -8,7 +8,7 @@ from . import core
 def test_PBO(fid: int) -> None:
     try:
         func = core.PBOFunction(fid, 0, 16)
-    except ImportError:
+    except ModuleNotFoundError:
         raise SkipTest("IOH is not installed")
     x = func.parametrization.sample()
     value = func(x.value)
@@ -20,7 +20,7 @@ def test_PBO(fid: int) -> None:
 def test_PBO_parameterization(instrumentation) -> None:
     try:
         func = core.PBOFunction(1, 0, 16, instrumentation=instrumentation)
-    except ImportError:
+    except ModuleNotFoundError:
         raise SkipTest("IOH is not installed")
     x = func.parametrization.sample()
     value = func(x.value)
@@ -31,7 +31,7 @@ def test_PBO_parameterization(instrumentation) -> None:
 def test_W_model() -> None:
     try:
         func = core.WModelFunction()
-    except ImportError:
+    except ModuleNotFoundError:
         raise SkipTest("IOH is not installed")
     x = func.parametrization.sample()
     func2 = core.PBOFunction(1, 0, 16)

--- a/nevergrad/functions/iohprofiler/test_core.py
+++ b/nevergrad/functions/iohprofiler/test_core.py
@@ -1,3 +1,4 @@
+from unittest import SkipTest
 import pytest
 import numpy as np
 from . import core
@@ -5,7 +6,10 @@ from . import core
 
 @pytest.mark.parametrize("fid", range(1, 24))  # type: ignore
 def test_PBO(fid: int) -> None:
-    func = core.PBOFunction(fid, 0, 16)
+    try:
+        func = core.PBOFunction(fid, 0, 16)
+    except ImportError:
+        raise SkipTest("IOH is not installed")
     x = func.parametrization.sample()
     value = func(x.value)
     assert isinstance(value, float), "All output of the iohprofiler-functions should be float"
@@ -14,7 +18,10 @@ def test_PBO(fid: int) -> None:
 
 @pytest.mark.parametrize("instrumentation", ["Softmax", "Ordered"])
 def test_PBO_parameterization(instrumentation) -> None:
-    func = core.PBOFunction(1, 0, 16, instrumentation=instrumentation)
+    try:
+        func = core.PBOFunction(1, 0, 16, instrumentation=instrumentation)
+    except ImportError:
+        raise SkipTest("IOH is not installed")
     x = func.parametrization.sample()
     value = func(x.value)
     assert isinstance(value, float), "All output of the iohprofiler-functions should be float"
@@ -22,7 +29,10 @@ def test_PBO_parameterization(instrumentation) -> None:
 
 
 def test_W_model() -> None:
-    func = core.WModelFunction()
+    try:
+        func = core.WModelFunction()
+    except ImportError:
+        raise SkipTest("IOH is not installed")
     x = func.parametrization.sample()
     func2 = core.PBOFunction(1, 0, 16)
     assert func(x.value) == func2(x.value), "W-model with default setting should equal base_function"

--- a/nevergrad/functions/iohprofiler/test_core.py
+++ b/nevergrad/functions/iohprofiler/test_core.py
@@ -16,8 +16,8 @@ def test_PBO(fid: int) -> None:
     assert np.isfinite(value)
 
 
-@pytest.mark.parametrize("instrumentation", ["Softmax", "Ordered"])
-def test_PBO_parameterization(instrumentation) -> None:
+@pytest.mark.parametrize("instrumentation", ["Softmax", "Ordered"])  # type: ignore
+def test_PBO_parameterization(instrumentation: str) -> None:
     try:
         func = core.PBOFunction(1, 0, 16, instrumentation=instrumentation)
     except ModuleNotFoundError:

--- a/requirements/bench.txt
+++ b/requirements/bench.txt
@@ -13,4 +13,4 @@ tqdm
 torchvision
 pyomo>=5.7
 mixsimulator>=0.2.9.5
-IOHexperimenter==0.2.8
+# IOHexperimenter==0.2.8  # buggy package on pypi

--- a/requirements/bench.txt
+++ b/requirements/bench.txt
@@ -12,5 +12,5 @@ Pillow
 tqdm
 torchvision
 pyomo>=5.7
-IOHexperimenter>=0.2.8
 mixsimulator>=0.2.9.5
+IOHexperimenter>=0.2.8

--- a/requirements/bench.txt
+++ b/requirements/bench.txt
@@ -13,4 +13,4 @@ tqdm
 torchvision
 pyomo>=5.7
 mixsimulator>=0.2.9.5
-IOHexperimenter>=0.2.8
+IOHexperimenter==0.2.8


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

IOHexperimenter package has been corrupted and messes up with the CI

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
