### PR TITLE
docs: fix simple typo, propotional -> proportional

### DIFF
--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -951,7 +951,7 @@ class SPSA(base.Optimizer):
         # then set c = standard deviation. 1e-1 is arbitrary.
         self.c = 1e-1
         # TODO: We should chose a to be inversely proportional to
-        # the magnitude of gradient and propotional to (1+A)^0.602
+        # the magnitude of gradient and proportional to (1+A)^0.602
         # we should spend some burn-in iterations to estimate the
         # magnitude of the gradient. 1e-5 is arbitrary.
         self.a = 1e-5


### PR DESCRIPTION
There is a small typo in nevergrad/optimization/optimizerlib.py.

Should read `proportional` rather than `propotional`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md