### PR TITLE
Fix DE multiobj tell-not-asked

### DIFF
--- a/nevergrad/optimization/differentialevolution.py
+++ b/nevergrad/optimization/differentialevolution.py
@@ -199,7 +199,7 @@ class _DE(base.Optimizer):
         if discardable is not None:  # if we found a point to kick, kick it
             del self.population[discardable]
             self._uid_queue.discard(discardable)
-        if len(self.population) >= self.llambda:  # if there is space, add the new point
+        if len(self.population) < self.llambda:  # if there is space, add the new point
             candidate.heritage["lineage"] = candidate.uid  # new lineage
             self.population[candidate.uid] = candidate
             self._uid_queue.tell(candidate.uid)

--- a/nevergrad/optimization/differentialevolution.py
+++ b/nevergrad/optimization/differentialevolution.py
@@ -170,6 +170,7 @@ class _DE(base.Optimizer):
         self._uid_queue.tell(uid)  # only add to queue if not a "tell_not_asked" (from a removed parent)
         parent = self.population[uid]
         mo_adapt = self._config.multiobjective_adaptation and self.num_objectives > 1
+        mo_adapt &= candidate._losses is not None  # can happen with bad constraints
         if not mo_adapt and loss <= base._loss(parent):
             self.population[uid] = candidate
         elif mo_adapt and (
@@ -182,18 +183,26 @@ class _DE(base.Optimizer):
             self.population[uid].heritage.update(candidate.heritage)
 
     def _internal_tell_not_asked(self, candidate: p.Parameter, loss: tp.FloatLoss) -> None:
-        worst: tp.Optional[p.Parameter] = None
+        discardable: tp.Optional[str] = None
         if len(self.population) >= self.llambda:
-            worst = max(self.population.values(), key=base._loss)
-            if worst.loss < loss:  # type: ignore
-                return  # no need to update
-            else:
-                uid = worst.heritage["lineage"]
-                del self.population[uid]
-                self._uid_queue.discard(uid)
-        candidate.heritage["lineage"] = candidate.uid  # new lineage
-        self.population[candidate.uid] = candidate
-        self._uid_queue.tell(candidate.uid)
+            if self.num_objectives == 1:  # monoobjective: replace if better
+                worst = max(self.population.values(), key=base._loss)
+                if loss < base._loss(worst):
+                    discardable = worst.heritage["lineage"]
+            else:  # multiobjective: replace if in pareto and some parents are not
+                pareto_uids = {c.uid for c in self.pareto_front()}
+                if candidate.uid in pareto_uids:
+                    non_pareto_pop = {c.uid for c in self.population.values()} - pareto_uids
+                    if non_pareto_pop:
+                        nonpareto = {c.uid: c for c in self.population.values()}[list(non_pareto_pop)[0]]
+                        discardable = nonpareto.heritage["lineage"]
+        if discardable is not None:  # if we found a point to kick, kick it
+            del self.population[discardable]
+            self._uid_queue.discard(discardable)
+        if len(self.population) >= self.llambda:  # if there is space, add the new point
+            candidate.heritage["lineage"] = candidate.uid  # new lineage
+            self.population[candidate.uid] = candidate
+            self._uid_queue.tell(candidate.uid)
 
 
 # pylint: disable=too-many-arguments, too-many-instance-attributes

--- a/nevergrad/optimization/test_optimizerlib.py
+++ b/nevergrad/optimization/test_optimizerlib.py
@@ -678,8 +678,13 @@ def test_ngopt_on_simple_realistic_scenario(budget: int, with_int: bool) -> None
     assert result < 5e-2 if with_int else 5e-3, f"{result} not < {5e-2 if with_int else 5e-3}"
 
 
-def test_constrained_de() -> None:
-    optimizer = optlib.DE(2, budget=20)
+def _multiobjective(z: np.ndarray) -> tp.Tuple[float, float, float]:
+    x, y = z
+    return (abs(x - 1), abs(y + 1), abs(x - y))
+
+
+def test_mo_constrained_de() -> None:
+    optimizer = optlib.DE(2, budget=60)
     optimizer.parametrization.random_state.seed(12)
 
     def constraint(arg: tp.Any) -> bool:  # pylint: disable=unused-argument
@@ -687,4 +692,6 @@ def test_constrained_de() -> None:
         return bool(optimizer.parametrization.random_state.rand() > 0.8)
 
     optimizer.parametrization.register_cheap_constraint(constraint)
-    optimizer.minimize(_square)
+    optimizer.minimize(_multiobjective)
+    point = optimizer.parametrization.spawn_child(new_value=np.array([1.0, 1.0]))
+    optimizer.tell(point, _multiobjective(point.value))

--- a/nevergrad/optimization/test_optimizerlib.py
+++ b/nevergrad/optimization/test_optimizerlib.py
@@ -693,5 +693,5 @@ def test_mo_constrained_de() -> None:
 
     optimizer.parametrization.register_cheap_constraint(constraint)
     optimizer.minimize(_multiobjective)
-    point = optimizer.parametrization.spawn_child(new_value=np.array([1.0, 1.0]))
+    point = optimizer.parametrization.spawn_child(new_value=np.array([1.0, 1.0]))  # on the pareto
     optimizer.tell(point, _multiobjective(point.value))


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Tell-not-asked were choosing points to discard in a non-expected way because it was based on the volume (which is dynamic). This now kicks non-pareto points if the tell-not-asked is in the pareto.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
