### PR TITLE
Remove pointless print

### DIFF
--- a/nevergrad/functions/rocket/rocket.py
+++ b/nevergrad/functions/rocket/rocket.py
@@ -66,7 +66,7 @@ def rocket(thrust_bias: np.ndarray):
         F_z = F * Ez / r
         F_x = F * (Ex / ((Ex ** 2 + Ey ** 2) ** 0.5))
         F_y = F * (Ey / ((Ex ** 2 + Ey ** 2) ** 0.5))
-        print(F_x, F_y, F_z, sep="\t")
+        # print(F_x, F_y, F_z, sep="\t")
         return F_x, F_y, F_z  # in the -r direction
 
     def drag_force(Ex, Ey, Ez, Evx, Evy, Evz):

--- a/nevergrad/functions/rocket/rocket.py
+++ b/nevergrad/functions/rocket/rocket.py
@@ -66,7 +66,6 @@ def rocket(thrust_bias: np.ndarray):
         F_z = F * Ez / r
         F_x = F * (Ex / ((Ex ** 2 + Ey ** 2) ** 0.5))
         F_y = F * (Ey / ((Ex ** 2 + Ey ** 2) ** 0.5))
-        # print(F_x, F_y, F_z, sep="\t")
         return F_x, F_y, F_z  # in the -r direction
 
     def drag_force(Ex, Ey, Ez, Evx, Evy, Evz):


### PR DESCRIPTION
Rockets should not waste time printing to stdout.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Rockets should not waste time printing in stdout.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
