### PR TITLE
[DRAFT] Added no_hypervolume option and return 0.0 loss in no_hypervolume case

### DIFF
--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -80,7 +80,7 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
     recast = False  # algorithm which were not designed to work with the suggest/update pattern
     one_shot = False  # algorithm designed to suggest all budget points at once
     no_parallelization = False  # algorithm which is designed to run sequentially only
-    no_hypervolume = False  # algorithm which is designed to not use the hypervolume method for MOO
+    no_hypervolume = False  # algorithm which doesn't require the use the hypervolume method for MOO and therefore doesn't perform it
 
     def __init__(
         self, parametrization: IntOrParameter, budget: tp.Optional[int] = None, num_workers: int = 1

--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -699,7 +699,7 @@ class ConfiguredOptimizer:
     recast = False  # algorithm which were not designed to work with the suggest/update pattern
     one_shot = False  # algorithm designed to suggest all budget points at once
     no_parallelization = False  # algorithm which is designed to run sequentially only
-    no_hypervolume = False  # algorithm which is designed to not use the hypervolume method for MOO
+    no_hypervolume = False  # algorithm which doesn't require the use the hypervolume method for MOO and therefore doesn't perform it
 
     def __init__(self, OptimizerClass: OptCls, config: tp.Dict[str, tp.Any], as_config: bool = False) -> None:
         self._OptimizerClass = OptimizerClass

--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -80,6 +80,7 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
     recast = False  # algorithm which were not designed to work with the suggest/update pattern
     one_shot = False  # algorithm designed to suggest all budget points at once
     no_parallelization = False  # algorithm which is designed to run sequentially only
+    no_hypervolume = False  # algorithm which is designed to not use the hypervolume method for MOO
 
     def __init__(
         self, parametrization: IntOrParameter, budget: tp.Optional[int] = None, num_workers: int = 1
@@ -342,7 +343,9 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
                 raise RuntimeError("MultiobjectiveReference can only be provided before the first tell.")
             if not isinstance(loss, np.ndarray):
                 raise RuntimeError("MultiobjectiveReference must only be used for multiobjective losses")
-            self._hypervolume_pareto = mobj.HypervolumePareto(upper_bounds=loss, seed=self._rng)
+            self._hypervolume_pareto = mobj.HypervolumePareto(
+                upper_bounds=loss, seed=self._rng, no_hypervolume=self.no_hypervolume
+            )
             if candidate.value is None:
                 return  # no value, so stopping processing there
             candidate = candidate.value
@@ -696,6 +699,7 @@ class ConfiguredOptimizer:
     recast = False  # algorithm which were not designed to work with the suggest/update pattern
     one_shot = False  # algorithm designed to suggest all budget points at once
     no_parallelization = False  # algorithm which is designed to run sequentially only
+    no_hypervolume = False  # algorithm which is designed to not use the hypervolume method for MOO
 
     def __init__(self, OptimizerClass: OptCls, config: tp.Dict[str, tp.Any], as_config: bool = False) -> None:
         self._OptimizerClass = OptimizerClass

--- a/nevergrad/optimization/multiobjective/core.py
+++ b/nevergrad/optimization/multiobjective/core.py
@@ -40,9 +40,11 @@ class HypervolumePareto:
 
     def __init__(
         self,
+        *,
         upper_bounds: tp.Optional[tp.ArrayLike] = None,
         auto_bound: int = AUTO_BOUND,
         seed: tp.Optional[tp.Union[int, np.random.RandomState]] = None,
+        no_hypervolume: bool = False,
     ) -> None:
         self._auto_bound = 0
         self._upper_bounds = (
@@ -55,6 +57,7 @@ class HypervolumePareto:
         self._best_volume = -float("Inf")
         self._hypervolume: tp.Optional[HypervolumeIndicator] = None
         self._pareto_needs_filtering = False
+        self._no_hypervolume = no_hypervolume
 
     @property
     def num_objectives(self) -> int:
@@ -78,6 +81,7 @@ class HypervolumePareto:
         """Given parameters and the multiobjective loss, this computes the hypervolume
         and update the state of the function with new points if it belongs to the pareto front
         """
+        # pylint: disable=too-many-return-statements, too-many-branches
         if not isinstance(parameter, p.Parameter):
             raise TypeError(
                 f"{self.__class__.__name__}.add should receive a ng.p.Parameter, but got: {parameter}."
@@ -103,14 +107,20 @@ class HypervolumePareto:
                 self._best_volume = loss
             if self._best_volume < 0:
                 self._add_to_pareto(parameter)
-            return -loss
+            if self._no_hypervolume:
+                return 0.0
+            else:
+                return -loss
         # We compute the hypervolume
         new_volume = self._hypervolume.compute([pa.losses for pa in self._pareto] + [losses])
         if new_volume > self._best_volume:
             # This point is good! Let us give him a great mono-fitness value.
             self._best_volume = new_volume
             self._add_to_pareto(parameter)
-            return -new_volume
+            if self._no_hypervolume:
+                return 0.0
+            else:
+                return -new_volume
         else:
             # This point is not on the front
             # First we prune.
@@ -122,7 +132,10 @@ class HypervolumePareto:
                 if (stored_losses <= losses).all():
                     distance_to_pareto = min(distance_to_pareto, min(losses - stored_losses))
             assert distance_to_pareto >= 0
-            return -new_volume + distance_to_pareto
+            if self._no_hypervolume:
+                return 0.0
+            else:
+                return -new_volume + distance_to_pareto
 
     def _filter_pareto_front(self) -> None:
         """Filters the Pareto front"""

--- a/nevergrad/optimization/multiobjective/test_core.py
+++ b/nevergrad/optimization/multiobjective/test_core.py
@@ -15,7 +15,7 @@ from . import core
 
 
 def test_hypervolume_pareto_function() -> None:
-    hvol = core.HypervolumePareto((100, 100))
+    hvol = core.HypervolumePareto(upper_bounds=(100, 100))
     tuples = [
         (110, 110),  # -0 + distance
         (110, 90),  # -0 + distance
@@ -39,7 +39,7 @@ def test_hypervolume_pareto_function() -> None:
 
 
 def test_hypervolume_pareto_with_no_good_point() -> None:
-    hvol = core.HypervolumePareto((100, 100))
+    hvol = core.HypervolumePareto(upper_bounds=(100, 100))
     tuples = [(110, 110), (110, 90), (90, 110)]
     values = []
     for tup in tuples:

--- a/nevergrad/optimization/recastlib.py
+++ b/nevergrad/optimization/recastlib.py
@@ -270,6 +270,7 @@ class Pymoo(base.ConfiguredOptimizer):
 
     recast = True
     no_parallelization = True
+    no_hypervolume = True
 
     # pylint: disable=unused-argument
     def __init__(self, *, algorithm: str) -> None:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue
Added option for no_hypervolume so that optimizers that do MOO without Hypervolume can be handled differently. In the case where hypervolume isn't needed, return 0.0 as the loss because `_internal_tell[_candidate]` does not look at loss in this context.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)
Ensure all tests run, and fixed test that failed as a result of making HypervolumePareto require keyword arguments.
<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
