### PR TITLE
Rely on CMA bounds if fully bounded

### DIFF
--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -2665,7 +2665,7 @@ class MultipleSingleRuns(base.ConfiguredOptimizer):
     # pylint: disable=unused-argument
     def __init__(
         self,
-        *
+        *,
         num_single_runs: int = 9,
         base_optimizer: base.OptCls = NGOpt,
     ) -> None:

--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -420,8 +420,8 @@ class _CMA(base.Optimizer):
                     CMA_elitist=self._config.elitist,
                 )
                 # Bullshit pseudo-code as a first step.
-                if self._use_bounded_mode and self.parametrization.upper and self.parametrization.lower:  # No idea how to check that.
-                    inopts["bounds"] = [lower, upper]
+                if p.helpers.Normalizer(self.parametrization).fully_bounded:
+                    inopts["bounds"] = [0, 1]
                 inopts.update(self._config.inopts if self._config.inopts is not None else {})
                 self._es = cma.CMAEvolutionStrategy(
                     x0=self.parametrization.sample().get_standardized_data(reference=self.parametrization)

--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -390,12 +390,10 @@ class _CMA(base.Optimizer):
         budget: tp.Optional[int] = None,
         num_workers: int = 1,
         config: tp.Optional["ParametrizedCMA"] = None,
-        use_bounded_mode: bool = False,
     ) -> None:
         super().__init__(parametrization, budget=budget, num_workers=num_workers)
         self._config = ParametrizedCMA() if config is None else config
         pop = self._config.popsize
-        self._use_bounded_mode = use_bounded_mode
         self._popsize = max(num_workers, 4 + int(3 * np.log(self.dimension))) if pop is None else pop
         # internal attributes
         self._to_be_asked: tp.Deque[np.ndarray] = deque()

--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -430,7 +430,7 @@ class _CMA(base.Optimizer):
                     x0=self.parametrization.sample().get_standardized_data(reference=self.parametrization)
                     if self._config.random_init
                     else np.zeros(self.dimension, dtype=np.float_),
-                    sigma0=self._config.scale,
+                    sigma0=self._config.scale if self._normalizer is None else 0.3,
                     inopts=inopts,
                 )
             else:

--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -517,6 +517,7 @@ class ParametrizedCMA(base.ConfiguredOptimizer):
         (see https://github.com/CMA-ES/pycma)
     use_cma_bounds: bool
         use CMA own bounding option (if the parametrization is fully bounded)
+        instead of relying on the parametrization system.
     """
 
     # pylint: disable=unused-argument


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

CMA seems to be better than our CMA in bounded contexts when the optima is on the frontier.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
