### PR TITLE
The user can modify NG_CPUS_PER_TASK

### DIFF
--- a/nevergrad/benchmark/xpbase.py
+++ b/nevergrad/benchmark/xpbase.py
@@ -7,10 +7,12 @@ import sys
 import time
 import random
 import numbers
+import os
 import warnings
 import traceback
 import typing as tp
 import numpy as np
+from concurrent import futures
 from nevergrad.parametrization import parameter as p
 from nevergrad.common import decorators
 from nevergrad.common import errors
@@ -57,7 +59,11 @@ class OptimizerSettings:
         self.optimizer = optimizer
         self.budget = budget
         self.num_workers = num_workers
-        self.executor = execution.MockedTimedExecutor(batch_mode)
+        ng_cpus_per_task = int(os.getenv("NG_CPUS_PER_TASK", "1"))
+        if ng_cpus_per_task > 0:
+            self.executor = futures.ThreadPoolExecutor(max_workers=ng_cpus_per_task)
+        else:
+            self.executor = execution.MockedTimedExecutor(batch_mode)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
The environment variable NG_CPUS_PER_TASK modifies the number of CPUs to be used per task.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Possibility to parallelize inside each run in benchmarks.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
