### PR TITLE
bad PR with big exception because I don't get it

### DIFF
--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -506,7 +506,7 @@ class _CMA(base.Optimizer):
             try:
                 data = learn_on_k_best(self.archive, sample_size)
                 return data  # type: ignore
-            except MetaModelFailure:  # Failures in the metamodeling can happen.
+            except:  # Failures in the metamodeling can happen.
                 pass
         if self._es is None:
             return pessimistic


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

When running on crop_simulator ("python -m nevergrad.benchmark crop_simulator --num_workers=2 --plot") I got this error:

Error when applying Experiment: Experiment: MetaModel<budget=50, num_workers=1, batch_mode=True> (dim=2, param=2hp:[ 0.35 35.  ]) on Instance of Cr
opSimulator(function_class='CropSimulator') with seed None:
Traceback (most recent call last):
  File "/private/home/oteytaud/nevergradpr/nevergrad/benchmark/xpbase.py", line 196, in run
    self._run_with_error()
  File "/private/home/oteytaud/nevergradpr/nevergrad/benchmark/xpbase.py", line 274, in _run_with_error
    raise e
  File "/private/home/oteytaud/nevergradpr/nevergrad/benchmark/xpbase.py", line 270, in _run_with_error
    executor=executor,
  File "/private/home/oteytaud/nevergradpr/nevergrad/optimization/base.py", line 659, in minimize
    args = self.ask()
  File "/private/home/oteytaud/nevergradpr/nevergrad/optimization/base.py", line 469, in ask
    candidate = self._internal_ask_candidate()
  File "/private/home/oteytaud/nevergradpr/nevergrad/optimization/optimizerlib.py", line 1609, in _internal_ask_candidate
    data = learn_on_k_best(self.archive, sample_size)
  File "/private/home/oteytaud/nevergradpr/nevergrad/optimization/metamodel.py", line 84, in learn_on_k_best
    raise MetaModelFailure("huge meta-model optimum in learn_on_k_best.")
nevergrad.optimization.metamodel.MetaModelFailure: huge meta-model optimum in learn_on_k_best.

I don't understand, because we should catch this.

## How Has This Been Tested (if it applies)

"python -m nevergrad.benchmark crop_simulator --num_workers=2 --plot" does not break anymore.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
