### PR TITLE
Fix: filenames too long

### DIFF
--- a/nevergrad/benchmark/plotting.py
+++ b/nevergrad/benchmark/plotting.py
@@ -655,7 +655,7 @@ class XpPlotter:
         output_filepath = str(output_filepath)
         if len(output_filepath) > 70:  # System limit of filename length.
             hashcode = hashlib.md5(bytes(output_filepath, "utf8")).hexdigest()
-            output_filepath = output_filepath[:35] + hashcode + output_filepath[-35:]        
+            output_filepath = output_filepath[:35] + hashcode + output_filepath[-35:]
         try:  # Let us catch errors due to too many DPIs.
             self._fig.savefig(
                 output_filepath, bbox_extra_artists=self._overlays, bbox_inches="tight", dpi=_DPI

--- a/nevergrad/benchmark/plotting.py
+++ b/nevergrad/benchmark/plotting.py
@@ -633,7 +633,10 @@ class XpPlotter:
             for i, l in zip(optim_vals[optim]["budget"], optim_vals[optim]["loss"]):
                 if l < best_performance[i][0]:
                     best_performance[i] = (l, optim)
-
+        output_filepath = str(output_filepath)
+        if len(output_filepath) > 70:
+            hashcode = hashlib.md5(bytes(output_filepath, "utf8")).hexdigest()
+            output_filepath = output_filepath[:35] + hashcode + output_filepath[-35:]
         with open(output_filepath, "w") as f:
             f.write("Best performance:\n")
             for i in best_performance.keys():
@@ -649,9 +652,13 @@ class XpPlotter:
         output_filepath: Path or str
             path where the figure must be saved
         """
+        output_filepath = str(output_filepath)
+        if len(output_filepath) > 70:  # System limit of filename length.
+            hashcode = hashlib.md5(bytes(output_filepath, "utf8")).hexdigest()
+            output_filepath = output_filepath[:35] + hashcode + output_filepath[-35:]        
         try:  # Let us catch errors due to too many DPIs.
             self._fig.savefig(
-                str(output_filepath), bbox_extra_artists=self._overlays, bbox_inches="tight", dpi=_DPI
+                output_filepath, bbox_extra_artists=self._overlays, bbox_inches="tight", dpi=_DPI
             )
         except ValueError as v:
             print(f"We catch {v} which means that image = too big.")


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Rare bug, but there are experiments for which some plots fail due to filename too long.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
