### PR TITLE
Use <= for budgets in fight_all plots instead of =

### DIFF
--- a/nevergrad/benchmark/plotting.py
+++ b/nevergrad/benchmark/plotting.py
@@ -88,7 +88,8 @@ def aggregate_winners(
         return aggregate_winners(df, categories[1:], all_optimizers)
     iterdf, iternum = zip(
         *(
-            aggregate_winners(df.loc[df.loc[:, categories[0]] == val], categories[1:], all_optimizers)
+            aggregate_winners(df.loc[df.loc[:, categories[0]] == val if categories[0] != "budget" else
+                                     df.loc[:, categories[0]] <= val], categories[1:], all_optimizers)
             for val in subcases
         )
     )


### PR DESCRIPTION
There are many cases in which we prefer to plot for budget up to XXX
instead of just budget == XXX.

Comments welcome --- for me this is a positive change, but maybe you feel differently.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Usually we just want results up to some budget, instead of just for one specific budget.

## How Has This Been Tested (if it applies)

I've plotted stuff and it was looking ok.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
