### PR TITLE
Fixing length of basenames in output files

### DIFF
--- a/nevergrad/benchmark/plotting.py
+++ b/nevergrad/benchmark/plotting.py
@@ -30,6 +30,16 @@ _DPI = 250
 # %% Basic tools
 
 
+def compactize(name: str) -> str:
+    if len(name) < 70:
+        return name
+    hashcode = hashlib.md5(bytes(name, "utf8")).hexdigest()
+    name = re.sub(r"\([^()]*\)", "", name)
+    mid = 35
+    name = name[:mid] + hashcode + name[-mid:]
+    return name
+
+
 def _make_style_generator() -> tp.Iterator[str]:
     lines = itertools.cycle(["-", "--", ":", "-."])  # 4
     markers = itertools.cycle("ov^<>8sp*hHDd")  # 13
@@ -327,6 +337,7 @@ def create_plots(
             # save
             name = "fight_" + ",".join("{}{}".format(x, y) for x, y in zip(fixed, case)) + ".png"
             name = "fight_all.png" if name == "fight_.png" else name
+            name = compactize(name)
 
             if name == "fight_all.png":
                 with open(str(output_folder / name) + ".cp.txt", "w") as f:
@@ -369,6 +380,7 @@ def create_plots(
     for case in cases:
         subdf = df.select_and_drop(**dict(zip(descriptors, case)))
         description = ",".join("{}:{}".format(x, y) for x, y in zip(descriptors, case))
+        description = compactize(description)
         if len(description) > 280:
             hash_ = hashlib.md5(bytes(description, "utf8")).hexdigest()
             description = description[:140] + hash_ + description[-140:]


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Sometimes long file names happen and break.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
