### PR TITLE
update ProcessPoolExecutor docs

### DIFF
--- a/nevergrad/benchmark/core.py
+++ b/nevergrad/benchmark/core.py
@@ -234,7 +234,7 @@ def _submit_jobs(
     seed: int
         a seed for the experiment plan (if seedable)
     executor: Executor-like object
-        an object such as concurrent.futures.ThreadPoolExecutor for running experiments in parallel
+        an object such as concurrent.futures.ProcessPoolExecutor for running experiments in parallel
     print_function: tp.Callable
         a function to print at the end of each experiment (for custom logging)
     cap_index: int
@@ -281,7 +281,7 @@ def compute(
     seed: int
         a seed for the experiment plan (if seedable)
     executor: Executor-like object
-        an object such as concurrent.futures.ThreadPoolExecutor for running experiments in parallel
+        an object such as concurrent.futures.ProcessPoolExecutor for running experiments in parallel
     print_function: tp.Callable
         a function to print at the end of each experiment (for custom logging)
     cap_index: int

--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -591,7 +591,7 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
             An executor object, with method :code:`submit(callable, *args, **kwargs)` and returning a Future-like object
             with methods :code:`done() -> bool` and :code:`result() -> float`. The executor role is to dispatch the execution of
             the jobs locally/on a cluster/with multithreading depending on the implementation.
-            Eg: :code:`concurrent.futures.ThreadPoolExecutor`
+            Eg: :code:`concurrent.futures.ProcessPoolExecutor`
         batch_mode: bool
             when :code:`num_workers = n > 1`, whether jobs are executed by batch (:code:`n` function evaluations are launched,
             we wait for all results and relaunch n evals) or not (whenever an evaluation is finished, we launch

--- a/nevergrad/optimization/test_doc.py
+++ b/nevergrad/optimization/test_doc.py
@@ -54,8 +54,10 @@ def test_base_example() -> None:
     from concurrent import futures
 
     optimizer = ng.optimizers.NGOpt(parametrization=instrum, budget=10, num_workers=2)
-
-    with futures.ProcessPoolExecutor(max_workers=optimizer.num_workers) as executor:
+    # We use ThreadPoolExecutor for CircleCI but please
+    # use the line below:
+    with futures.ThreadPoolExecutor(max_workers=optimizer.num_workers) as executor:
+    #with futures.ProcessPoolExecutor(max_workers=optimizer.num_workers) as executor:
         recommendation = optimizer.minimize(square, executor=executor, batch_mode=False)
     # DOC_BASE_3
     import nevergrad as ng

--- a/nevergrad/optimization/test_doc.py
+++ b/nevergrad/optimization/test_doc.py
@@ -55,7 +55,7 @@ def test_base_example() -> None:
 
     optimizer = ng.optimizers.NGOpt(parametrization=instrum, budget=10, num_workers=2)
 
-    with futures.ThreadPoolExecutor(max_workers=optimizer.num_workers) as executor:
+    with futures.ProcessPoolExecutor(max_workers=optimizer.num_workers) as executor:
         recommendation = optimizer.minimize(square, executor=executor, batch_mode=False)
     # DOC_BASE_3
     import nevergrad as ng


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
ThreadPoolExecutor use only one thread for all task in async due to GIL lock (one interpreter = one thread). For CPU-bound function ProcessPoolExecutor circumvent this issue.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)
```
import nevergrad as ng
from concurrent import futures
import time
import multiprocessing as mp

from nevergrad.optimization import optimizerlib

def func(x):
    tmp = 1
    for k in range(4_000_000):#Garbage calculation
        tmp += 1
        tmp -= 1
    return sum((x-1)**2)*tmp
 parametrization = ng.p.Array(shape=(10,))

start = time.time()
budget = 100

optim = optimizerlib.OnePlusOne(parametrization=parametrization, budget=budget, num_workers=10)
# recom = optim.minimize(func, executor=futures.ThreadPoolExecutor(max_workers=optim.num_workers))
recom = optim.minimize(func, executor=futures.ProcessPoolExecutor(max_workers=optim.num_workers, mp_context=mp.get_context('fork')))# Spawn mode raise an error, so it will not work on windows.

end = time.time()
print(end - start)
```
<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [ ] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
