### PR TITLE
Sometimes a nparray has no len

### DIFF
--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -318,7 +318,7 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
         will use this suggestion.
         """
         # Check loss type
-        if isinstance(loss, (Real, float)) or (isinstance(loss, np.ndarray) and len(loss.shape) == 0):
+        if isinstance(loss, (Real, float)) or (isinstance(loss, np.ndarray) and not loss.shape):
             # using "float" along "Real" because mypy does not understand "Real" for now Issue #3186
             loss = float(loss)
             # Non-sense values including NaNs should not be accepted.

--- a/nevergrad/optimization/base.py
+++ b/nevergrad/optimization/base.py
@@ -318,7 +318,7 @@ class Optimizer:  # pylint: disable=too-many-instance-attributes
         will use this suggestion.
         """
         # Check loss type
-        if isinstance(loss, (Real, float)):
+        if isinstance(loss, (Real, float)) or (isinstance(loss, np.ndarray) and len(loss.shape) == 0):
             # using "float" along "Real" because mypy does not understand "Real" for now Issue #3186
             loss = float(loss)
             # Non-sense values including NaNs should not be accepted.


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

If the loss is a scalar ndarray our code was crashing (just below, because it has no len).

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
