### PR TITLE
Removed duplicate RotatedTwoPointsDE

### DIFF
--- a/nevergrad/benchmark/experiments.py
+++ b/nevergrad/benchmark/experiments.py
@@ -633,7 +633,6 @@ def bonnans(seed: tp.Optional[int] = None) -> tp.Iterator[Experiment]:
         "DiscreteBSOOnePlusOne",
         "AdaptiveDiscreteOnePlusOne",
         "GeneticDE",
-        "RotatedTwoPointsDE",
         "DE",
         "TwoPointsDE",
         "DiscreteOnePlusOne",


### PR DESCRIPTION
In a long list of optimizers this one was accidentally included twice.