### PR TITLE
Adding relative improvement as stopping criterion

### DIFF
--- a/nevergrad/optimization/test_callbacks.py
+++ b/nevergrad/optimization/test_callbacks.py
@@ -130,7 +130,7 @@ def test_early_stopping() -> None:
 
 def test_improvement_criterion() -> None:
     optim = optimizerlib.OnePlusOne(2, budget=100)
-    crit = ng.callbacks.EarlyStopping.relative_improvement(min_improvement = 0.01)
+    crit = ng.callbacks._RelImprovementCriterion(min_improvement = 0.01)
     assert not crit(optim)
     assert not crit(optim)
     assert not crit(optim)

--- a/nevergrad/optimization/test_callbacks.py
+++ b/nevergrad/optimization/test_callbacks.py
@@ -128,6 +128,15 @@ def test_early_stopping() -> None:
     assert optimizer.recommend().loss < 12  # type: ignore
 
 
+def test_improvement_criterion() -> None:
+    optim = optimizerlib.OnePlusOne(2, budget=100)
+    crit = ng.callbacks.EarlyStopping.relative_improvement(min_improvement = 0.01)
+    assert not crit(optim)
+    assert not crit(optim)
+    assert not crit(optim)
+    time.sleep(0.01)
+    assert crit(optim)
+
 def test_duration_criterion() -> None:
     optim = optimizerlib.OnePlusOne(2, budget=100)
     crit = ng.callbacks._DurationCriterion(0.01)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->Adding the relative improvement as a stopping criterion callback to the ```base.Optimizer.minimize``` method
<!--- Please link to an existing issue here if one exists. -->#589
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. --> i took some parts from the script ```test_callbacks.py``` and run some tests with different thresholds, the thing seems to work properly. After i added the test function in an analogous format as the one done for ```test_duration_criterion```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [x ] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
