### PR TITLE
EarlyStopping based no improvement interval

### DIFF
--- a/nevergrad/optimization/callbacks.py
+++ b/nevergrad/optimization/callbacks.py
@@ -350,7 +350,8 @@ class EarlyStopping:
     @classmethod
     def no_improvement_stopper(cls, tolerance_window: int) -> "EarlyStopping":
         """Early stop when loss didn't reduce during tolerance_window asks"""
-        return cls(_LossImporvementToleranceCriterion(tolerance_window))
+        return cls(_LossImprovementToleranceCriterion(tolerance_window))
+
 
 class _DurationCriterion:
     def __init__(self, max_duration: float) -> None:
@@ -363,7 +364,7 @@ class _DurationCriterion:
         return time.time() > self._start + self._max_duration
 
 
-class _LossImporvementToleranceCriterion:
+class _LossImprovementToleranceCriterion:
     def __init__(self, tolerance_window: int) -> None:
         self._tolerance_window = tolerance_window
         self._best_value = None

--- a/nevergrad/optimization/callbacks.py
+++ b/nevergrad/optimization/callbacks.py
@@ -349,7 +349,7 @@ class EarlyStopping:
 
     @classmethod
     def no_improvement_stopper(cls, tolerance_window: int) -> "EarlyStopping":
-        """Early stop when no loss reduce during tolerance_window asks"""
+        """Early stop when loss didn't reduce during tolerance_window asks"""
         return cls(_LossImporvementToleranceCriterion(tolerance_window))
 
 class _DurationCriterion:

--- a/nevergrad/optimization/callbacks.py
+++ b/nevergrad/optimization/callbacks.py
@@ -366,9 +366,9 @@ class _DurationCriterion:
 
 class _LossImprovementToleranceCriterion:
     def __init__(self, tolerance_window: int) -> None:
-        self._tolerance_window = tolerance_window
-        self._best_value = None
-        self._tolerance_count = 0
+        self._tolerance_window: int = tolerance_window
+        self._best_value: tp.Optional[np.ndarray] = None
+        self._tolerance_count: int = 0
 
     def __call__(self, optimizer: base.Optimizer) -> bool:
         best_param = optimizer.provide_recommendation()

--- a/nevergrad/optimization/test_callbacks.py
+++ b/nevergrad/optimization/test_callbacks.py
@@ -135,7 +135,7 @@ def test_early_stopping() -> None:
     func = _EarlyStoppingTestee(5)
     optimizer = optimizerlib.OnePlusOne(parametrization=instrum, budget=100)
     no_imp_window=7
-    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should triggered
+    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should get triggered
     optimizer.minimize(func, verbosity=2)
     assert(func.num_calls == no_imp_window+2)
 
@@ -143,7 +143,7 @@ def test_early_stopping() -> None:
     func = _EarlyStoppingTestee(5, multi=True)
     optimizer = optimizerlib.OnePlusOne(parametrization=instrum, budget=100)
     no_imp_window=5
-    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should triggered
+    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should get triggered
     optimizer.minimize(func, verbosity=2)
     assert(func.num_calls == no_imp_window+2)
 

--- a/nevergrad/optimization/test_callbacks.py
+++ b/nevergrad/optimization/test_callbacks.py
@@ -105,16 +105,16 @@ def test_progressbar_dump(tmp_path: Path) -> None:
 
 
 class _EarlyStoppingTestee:
-    def __init__(self, val = None, multi=False) -> None:
+    def __init__(self, val=None, multi=False) -> None:
         self.num_calls = 0
         self.val = val
         self.multi = False
 
-    def __call__(self, *args, **kwds) -> float:
+    def __call__(self, *args, **kwds) -> tp.Union[float, tp.Tuple]:
         self.num_calls += 1
         if self.val is not None:
-            return self.val if not self.multi else (self.val,self.val)
-        return np.random.rand()  if not self.multi else (np.random.rand(),np.random.rand())
+            return self.val if not self.multi else (self.val, self.val)
+        return np.random.rand() if not self.multi else (np.random.rand(), np.random.rand())
 
 
 def test_early_stopping() -> None:
@@ -131,21 +131,26 @@ def test_early_stopping() -> None:
     assert optimizer.current_bests["minimum"].mean < 12
     assert optimizer.recommend().loss < 12  # type: ignore
 
-    #test for no improvement
+    # test for no improvement
     func = _EarlyStoppingTestee(5)
     optimizer = optimizerlib.OnePlusOne(parametrization=instrum, budget=100)
-    no_imp_window=7
-    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should get triggered
+    no_imp_window = 7
+    optimizer.register_callback(
+        "ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window)
+    )  # should get triggered
     optimizer.minimize(func, verbosity=2)
-    assert(func.num_calls == no_imp_window+2)
+    assert func.num_calls == no_imp_window + 2
 
-    #test for no improvement multi objective
+    # test for no improvement multi objective
     func = _EarlyStoppingTestee(5, multi=True)
     optimizer = optimizerlib.OnePlusOne(parametrization=instrum, budget=100)
-    no_imp_window=5
-    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should get triggered
+    no_imp_window = 5
+    optimizer.register_callback(
+        "ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window)
+    )  # should get triggered
     optimizer.minimize(func, verbosity=2)
-    assert(func.num_calls == no_imp_window+2)
+    assert func.num_calls == no_imp_window + 2
+
 
 def test_duration_criterion() -> None:
     optim = optimizerlib.OnePlusOne(2, budget=100)

--- a/nevergrad/optimization/test_callbacks.py
+++ b/nevergrad/optimization/test_callbacks.py
@@ -135,7 +135,7 @@ def test_early_stopping() -> None:
     func = _EarlyStoppingTestee(5)
     optimizer = optimizerlib.OnePlusOne(parametrization=instrum, budget=100)
     no_imp_window=7
-    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should not get triggered
+    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should triggered
     optimizer.minimize(func, verbosity=2)
     assert(func.num_calls == no_imp_window+2)
 
@@ -143,7 +143,7 @@ def test_early_stopping() -> None:
     func = _EarlyStoppingTestee(5, multi=True)
     optimizer = optimizerlib.OnePlusOne(parametrization=instrum, budget=100)
     no_imp_window=5
-    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should not get triggered
+    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should triggered
     optimizer.minimize(func, verbosity=2)
     assert(func.num_calls == no_imp_window+2)
 

--- a/nevergrad/optimization/test_callbacks.py
+++ b/nevergrad/optimization/test_callbacks.py
@@ -105,12 +105,16 @@ def test_progressbar_dump(tmp_path: Path) -> None:
 
 
 class _EarlyStoppingTestee:
-    def __init__(self) -> None:
+    def __init__(self, val = None, multi=False) -> None:
         self.num_calls = 0
+        self.val = val
+        self.multi = False
 
     def __call__(self, *args, **kwds) -> float:
         self.num_calls += 1
-        return np.random.rand()
+        if self.val is not None:
+            return self.val if not self.multi else (self.val,self.val)
+        return np.random.rand()  if not self.multi else (np.random.rand(),np.random.rand())
 
 
 def test_early_stopping() -> None:
@@ -127,6 +131,21 @@ def test_early_stopping() -> None:
     assert optimizer.current_bests["minimum"].mean < 12
     assert optimizer.recommend().loss < 12  # type: ignore
 
+    #test for no improvement
+    func = _EarlyStoppingTestee(5)
+    optimizer = optimizerlib.OnePlusOne(parametrization=instrum, budget=100)
+    no_imp_window=7
+    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should not get triggered
+    optimizer.minimize(func, verbosity=2)
+    assert(func.num_calls == no_imp_window+2)
+
+    #test for no improvement multi objective
+    func = _EarlyStoppingTestee(5, multi=True)
+    optimizer = optimizerlib.OnePlusOne(parametrization=instrum, budget=100)
+    no_imp_window=5
+    optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  # should not get triggered
+    optimizer.minimize(func, verbosity=2)
+    assert(func.num_calls == no_imp_window+2)
 
 def test_duration_criterion() -> None:
     optim = optimizerlib.OnePlusOne(2, budget=100)


### PR DESCRIPTION
## Types of changes

TL;DR

Early stop when no loss reduces during tolerance_window asks
Example of using :
`     optimizer.register_callback("ask", ng.callbacks.EarlyStopping.no_improvement_stopper(no_imp_window))  
`


tested python3 -m pytest test_callbacks.py

- [*] New feature (non-breaking change which adds functionality)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
Provide early stoping feedback based on no improvemen frequent case for optimization
<!--- Please link to an existing issue here if one exists. -->
there are several issues connected to that early stoping implementation
https://github.com/facebookresearch/nevergrad/issues/714
https://github.com/facebookresearch/nevergrad/issues/589

## How Has This Been Tested (if it applies)
I've provided different unit tests  to test it
python3 -m pytest test_callbacks.py

## Checklist


- [ ?] The documentation is up-to-date with the changes I made: there no place on github to add it
- [ x] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [ x] All tests passed, and additional code has been covered with new tests.


