### PR TITLE
Update sphere.py

### DIFF
--- a/nevergrad/common/sphere.py
+++ b/nevergrad/common/sphere.py
@@ -20,6 +20,9 @@ import nevergrad as ng
 # pylint: skip-file
 
 default_budget = 3000  # centiseconds
+default_steps=100 #nb of steps grad descent
+default_order=2 #Riesz energy order
+default_stepsize=10 #step size for grad descent
 methods = {}
 metrics = {}
 
@@ -40,7 +43,10 @@ def convo(x, k):
         return x
     return scipy.ndimage.gaussian_filter(x, sigma=list(k) + [0.0] * (len(x.shape) - len(k)))
 
-
+def convo_mult(x,k): #Convo for an array of different points
+    if k is None:
+        return x
+    return scipy.ndimage.gaussian_filter(x, sigma=[0]+list(k) + [0.0] * (len(x.shape) - len(k)-1))
 # Our well distributed point configurations.
 def pure_random(n, shape, conv=None):
     return normalize([np.random.randn(*shape) for i in range(n)])
@@ -144,6 +150,122 @@ def dispersion_with_mini_conv(n, shape, budget=default_budget):
 
 def greedy_dispersion_with_mini_conv(n, shape, budget=default_budget):
     return greedy_dispersion(n, shape, budget=budget, conv=[2, 2])
+
+
+
+def Riesz_blurred_gradient(n, shape, budget=default_steps,order=default_order,step_size=default_stepsize, conv=None):
+    t=(n,)+shape
+    x = np.random.randn(*t)
+    x=normalize(x)
+    for steps in range(budget):
+        Temp=np.zeros(t)
+        Blurred=convo_mult(x,conv)
+        for i in range(n):
+            for j in range(n):
+                if (j!=i):
+                    T=np.add(Blurred[i],-Blurred[j])
+                    Temp[i]=np.add(Temp[i],np.multiply(T,1/(np.sqrt(np.sum(T ** 2.0)))**(order+2)))
+            Temp[i]=np.multiply(Temp[i],step_size)
+        x=np.add(x,Temp)
+        x=normalize(x)
+    return x
+
+
+def Riesz_blursum_gradient(n, shape, budget=default_steps,order=default_order,step_size=default_stepsize, conv=None):
+    t=(n,)+shape
+    x = np.random.randn(*t)
+    x=normalize(x)
+    for steps in range(budget):
+        Blurred=np.zeros(t)
+        for i in range(n):
+            for j in range(n):
+                if (j!=i):
+                    T=np.add(x[i],-x[j])
+                    Blurred[i]=np.add(np.multiply(T,1/(np.sqrt(np.sum(T ** 2.0)))**(order+2)),Blurred[i])
+        Blurred=convo_mult(Blurred,conv)
+        x=np.add(x,Blurred)
+        x=normalize(x)
+    return x
+
+def Riesz_noblur_gradient(n, shape, budget=default_steps,order=default_order,step_size=default_stepsize, conv=None):
+    t=(n,)+shape
+    x = np.random.randn(*t)
+    x=normalize(x)
+    for steps in range(budget):
+        Temp=np.zeros(t)
+        for i in range(n):
+            for j in range(n):
+                 if (j!=i):
+                    T=np.add(x[i],-x[j])
+                    Temp[i]=np.add(Temp[i],np.multiply(T,1/(np.sqrt(np.sum(T ** 2.0)))**(order+2)))
+        x=np.add(x,Temp)
+        x=normalize(x)
+    return x
+            
+def Riesz_noblur_bigconv_loworder(n,shape,budget=default_budget):
+    return Riesz_noblur_gradient(n,shape,default_steps,order=0.5,step_size=default_stepsize,conv=[24,24])
+def Riesz_noblur_bigconv_midorder(n,shape,budget=default_budget):
+    return Riesz_noblur_gradient(n,shape,default_steps,order=1,step_size=default_stepsize,conv=[24,24])
+def Riesz_noblur_bigconv_highorder(n,shape,budget=default_budget):
+    return Riesz_noblur_gradient(n,shape,default_steps,order=2,step_size=default_stepsize,conv=[24,24])
+
+def Riesz_noblur_medconv_loworder(n,shape,budget=default_budget):
+    return Riesz_noblur_gradient(n,shape,default_steps,order=0.5,step_size=default_stepsize,conv=[8,8])
+def Riesz_noblur_medconv_midorder(n,shape,budget=default_budget):
+    return Riesz_noblur_gradient(n,shape,default_steps,order=1,step_size=default_stepsize,conv=[8,8])
+def Riesz_noblur_medconv_highorder(n,shape,budget=default_budget):
+    return Riesz_noblur_gradient(n,shape,default_steps,order=2,step_size=default_stepsize,conv=[8,8])
+
+def Riesz_noblur_lowconv_loworder(n,shape,budget=default_budget):
+    return Riesz_noblur_gradient(n,shape,default_steps,order=0.5,step_size=default_stepsize,conv=[2,2])
+def Riesz_noblur_lowconv_midorder(n,shape,budget=default_budget):
+    return Riesz_noblur_gradient(n,shape,default_steps,order=1,step_size=default_stepsize,conv=[2,2])
+def Riesz_noblur_lowconv_highorder(n,shape,budget=default_budget):
+    return Riesz_noblur_gradient(n,shape,default_steps,order=2,step_size=default_stepsize,conv=[2,2])
+
+def Riesz_blursum_bigconv_loworder(n,shape,budget=default_budget):
+    return Riesz_blursum_gradient(n,shape,default_steps,order=0.5,step_size=default_stepsize,conv=[24,24])
+def Riesz_blursum_bigconv_midorder(n,shape,budget=default_budget):
+    return Riesz_blursum_gradient(n,shape,default_steps,order=1,step_size=default_stepsize,conv=[24,24])
+def Riesz_blursum_bigconv_highorder(n,shape,budget=default_budget):
+    return Riesz_blursum_gradient(n,shape,default_steps,order=2,step_size=default_stepsize,conv=[24,24])
+
+def Riesz_blursum_medconv_loworder(n,shape,budget=default_budget):
+    return Riesz_blursum_gradient(n,shape,default_steps,order=0.5,step_size=default_stepsize,conv=[8,8])
+def Riesz_blursum_medconv_midorder(n,shape,budget=default_budget):
+    return Riesz_blursum_gradient(n,shape,default_steps,order=1,step_size=default_stepsize,conv=[8,8])
+def Riesz_blursum_medconv_highorder(n,shape,budget=default_budget):
+    return Riesz_blursum_gradient(n,shape,default_steps,order=2,step_size=default_stepsize,conv=[8,8])
+
+def Riesz_blursum_lowconv_loworder(n,shape,budget=default_budget):
+    return Riesz_blursum_gradient(n,shape,default_steps,order=0.5,step_size=default_stepsize,conv=[2,2])
+def Riesz_blursum_lowconv_midorder(n,shape,budget=default_budget):
+    return Riesz_blursum_gradient(n,shape,default_steps,order=1,step_size=default_stepsize,conv=[2,2])
+def Riesz_blursum_lowconv_highorder(n,shape,budget=default_budget):
+    return Riesz_blursum_gradient(n,shape,default_steps,order=2,step_size=default_stepsize,conv=[2,2])
+
+
+def Riesz_blurred_bigconv_loworder(n,shape,budget=default_budget):
+    return Riesz_blurred_gradient(n,shape,default_steps,order=0.5,step_size=default_stepsize,conv=[24,24])
+def Riesz_blurred_bigconv_midorder(n,shape,budget=default_budget):
+    return Riesz_blurred_gradient(n,shape,default_steps,order=1,step_size=default_stepsize,conv=[24,24])
+def Riesz_blurred_bigconv_highorder(n,shape,budget=default_budget):
+    return Riesz_blurred_gradient(n,shape,default_steps,order=2,step_size=default_stepsize,conv=[24,24])
+
+def Riesz_blurred_medconv_loworder(n,shape,budget=default_budget):
+    return Riesz_blurred_gradient(n,shape,default_steps,order=0.5,step_size=default_stepsize,conv=[8,8])
+def Riesz_blurred_medconv_midorder(n,shape,budget=default_budget):
+    return Riesz_blurred_gradient(n,shape,default_steps,order=1,step_size=default_stepsize,conv=[8,8])
+def Riesz_blurred_medconv_highorder(n,shape,budget=default_budget):
+    return Riesz_blurred_gradient(n,shape,default_steps,order=2,step_size=default_stepsize,conv=[8,8])
+
+def Riesz_blurred_lowconv_loworder(n,shape,budget=default_budget):
+    return Riesz_blurred_gradient(n,shape,default_steps,order=0.5,step_size=default_stepsize,conv=[2,2])
+def Riesz_blurred_lowconv_midorder(n,shape,budget=default_budget):
+    return Riesz_blurred_gradient(n,shape,default_steps,order=1,step_size=default_stepsize,conv=[2,2])
+def Riesz_blurred_lowconv_highorder(n,shape,budget=default_budget):
+    return Riesz_blurred_gradient(n,shape,default_steps,order=2,step_size=default_stepsize,conv=[2,2])
+
 
 
 def block_symmetry(n, shape, num_blocks=None):
@@ -503,6 +625,33 @@ list_of_methods = [
     "rs_rac",
     "rs_rac2",
     "rs_rac05",
+    "Riesz_blurred_bigconv_loworder",
+    "Riesz_blurred_bigconv_midorder",
+    "Riesz_blurred_bigconv_highorder",
+    "Riesz_blurred_medconv_loworder",
+    "Riesz_blurred_medconv_midorder",
+    "Riesz_blurred_medconv_highorder",
+    "Riesz_blurred_lowconv_loworder",
+    "Riesz_blurred_lowconv_midorder",
+    "Riesz_blurred_lowconv_highorder",
+    "Riesz_noblur_bigconv_loworder",
+    "Riesz_noblur_bigconv_midorder",
+    "Riesz_noblur_bigconv_highorder",
+    "Riesz_noblur_medconv_loworder",
+    "Riesz_noblur_medconv_midorder",
+    "Riesz_noblur_medconv_highorder",
+    "Riesz_noblur_lowconv_loworder",
+    "Riesz_noblur_lowconv_midorder",
+    "Riesz_noblur_lowconv_highorder",
+    "Riesz_blursum_bigconv_loworder",
+    "Riesz_blursum_bigconv_midorder",
+    "Riesz_blursum_bigconv_highorder",
+    "Riesz_blursum_medconv_loworder",
+    "Riesz_blursum_medconv_midorder",
+    "Riesz_blursum_medconv_highorder",
+    "Riesz_blursum_lowconv_loworder",
+    "Riesz_blursum_lowconv_midorder",
+    "Riesz_blursum_lowconv_highorder",
 ]
 list_metrics = [
     "metric_half",
@@ -824,6 +973,8 @@ def bigcheck():
         "covering",
         "covering_conv",
         "covering_mini_conv",
+        "Riesz_blurred_bigconv_highorder",
+        "Riesz_blursum_bigconv_highorder",
     ]:
         print("Starting to play with ", k)
         eval(f"{k}(n, shape)")


### PR DESCRIPTION
Added Riesz energy gradient descents: 3 options (blurred, blursum and noblur) plus methods to call with different conv and order parameters. Extra convo function to calculate for all the points at once.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
New approach for spreading out points.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
Tried all the methods to check that the gradient descent was working properly and returned a point set of the correct format. No guarantee on the correctness apart from looking OK.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [ ] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
