### PR TITLE
Convert the CircleCI workflow to a GitHub Actions workflow

### DIFF
--- a/.github/actions/ubuntu_restore_all/action.yml
+++ b/.github/actions/ubuntu_restore_all/action.yml
@@ -1,0 +1,24 @@
+name: ubuntu_restore_all
+runs:
+  using: composite
+  steps:
+  - uses: actions/checkout@v4.1.0
+  - name: restore_cache
+    uses: actions/cache@v3.3.2
+    with:
+      key: v4-dependencies-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/main.txt"}}-{{ checksum "requirements/bench.txt"}}
+      path: UPDATE_ME
+      restore-keys: |
+        v4-dependencies-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/main.txt"}}-{{ checksum "requirements/bench.txt"}}
+        v4-dependencies-main-{{ checksum "requirements/main.txt"}}
+  - name: "[all] Install dependencies"
+    run: |
+      #python3 -m venv venv
+      rm -rf venv && python3 -m venv venv
+      . venv/bin/activate
+      pip install --progress-bar off -U pip setuptools
+      pip install --progress-bar off -e .[all]
+      #pip install --progress-bar off --use-deprecated=legacy-resolver -e .[all]
+      pip install --progress-bar off -U numpy>=1.20.0
+      pip install keras==2.6.0  # issue on Nov 4th 2021
+    shell: bash

--- a/.github/workflows/all_ci.yml
+++ b/.github/workflows/all_ci.yml
@@ -1,0 +1,222 @@
+name: facebookresearch/nevergrad/all_ci
+on:
+  push:
+    branches:
+    - main
+env:
+  PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+  CIRCLE_REPOSITORY_URL: ${{ github.CIRCLE_REPOSITORY_URL }}
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+    - uses: actions/checkout@v4.1.0
+    - name: restore_cache
+      uses: actions/cache@v3.3.2
+      with:
+        key: v4-dependencies-main-{{ checksum "requirements/main.txt"}}
+        path: "./venv"
+        restore-keys: v4-dependencies-main-{{ checksum "requirements/main.txt"}}
+    - name: "[no-extra] Install dependencies"
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ ]]; then
+          rm -rf venv && python3 -m venv venv
+          . venv/bin/activate
+          pip install --progress-bar off pip==23.2
+          pip install --progress-bar off -e .
+        fi
+    - name: "[no-extra] Print installation"
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ ]]; then
+          if [[ -z "$CIRCLE_REPOSITORY_URL" ]]; then
+              echo "CIRCLE_REPOSITORY_URL must be provided in environment" 1>&2
+              exit 1
+          fi
+          echo "This is on $CIRCLE_REPOSITORY_URL."
+          . venv/bin/activate
+          pip freeze
+        fi
+    - name: "[no-extra] Run basic tests (checking dependencies)"
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ ]]; then
+          . venv/bin/activate
+          python -m nevergrad.optimization.requirements_check  # calls a bit of everything
+        fi
+    - uses: "./.github/actions/ubuntu_restore_all"
+    - name: save_cache
+      uses: actions/cache@v3.3.2
+      with:
+        path: "./venv"
+        key: v4-dependencies-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/main.txt"}}-{{ checksum "requirements/bench.txt"}}
+    - name: "[all] Print installation"
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ ]]; then
+          . venv/bin/activate
+          pip freeze
+        fi
+    - name: Run wheel and check package
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ ]]; then
+          . venv/bin/activate
+          pip install wheel
+          rm -rf dist  # make sure it's clean
+          echo "Creating sdist"
+          python setup.py sdist
+          echo "Created sdist, now creating wheel"
+          python setup.py bdist_wheel
+          echo "Created wheel"
+          mkdir nevergrad-build
+          mv dist nevergrad-build/
+          python -c "from pathlib import Path;files = Path('nevergrad.egg-info/SOURCES.txt').read_text().split(); assert 'LICENSE' in files"
+          python3 -m venv test_wheel
+          . test_wheel/bin/activate
+          pip install -U pip
+          cd ..  # don't use nevergrad locally
+          echo "Installing wheel"
+          pip install --progress-bar off repo/nevergrad-build/dist/nevergrad-*any.whl
+          #pip install --progress-bar off --use-deprecated=legacy-resolver repo/nevergrad-build/dist/nevergrad-*any.whl
+          echo "Installed wheel"
+          python -c "from nevergrad import functions;f = functions.ArtificialFunction(name='sphere', block_dimension=2);f([2, 3])"
+        fi
+    - uses: actions/upload-artifact@v4.0.0
+      with:
+        path: nevergrad-build/dist
+    - name: Build docs
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ ]]; then
+          . venv/bin/activate
+          cd docs/
+          make html
+        fi
+    - uses: actions/upload-artifact@v4.0.0
+      with:
+        path: docs/_build/html
+  static:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/ubuntu_restore_all"
+    - name: Run mypy
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ ]]; then
+          . venv/bin/activate
+          mypy --version
+          mypy nevergrad
+        fi
+    - name: Run basic pylint
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ ]]; then
+          . venv/bin/activate
+          pylint --version
+          pylint nevergrad --disable=all --enable=unused-import,unused-argument,unused-variable,undefined-loop-variable,redefined-builtin,used-before-assignment,super-init-not-called,useless-super-delegation,dangerous-default-value,unnecessary-pass,attribute-defined-outside-init
+        fi
+    - name: Run black
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ ]]; then
+          . venv/bin/activate
+          pip install black
+          black --version
+          black nevergrad --check --diff
+        fi
+  pytests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/ubuntu_restore_all"
+    - name: "[all] Run pytest"
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ ]]; then
+          . venv/bin/activate
+          pip install pytest
+          pytest --circleci-parallelize nevergrad -v --durations=20 --cov=nevergrad
+          #pytest nevergrad -v --exitfirst --durations=20 --cov=nevergrad
+        fi
+  docs-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+    - uses: actions/checkout@v4.1.0
+    # Ensure parameter if_key_exists is set correctly
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2.6.1
+      with:
+        key: "${{ secrets.CIRCLE_CI_SSH_KEY }}"
+        name: circle_ci_id_rsa
+        known_hosts: "${{ secrets.CIRCLE_CI_KNOWN_HOSTS }}"
+        if_key_exists: fail
+    - uses: actions/download-artifact@v4.1.0
+      with:
+        path: docs/_build
+    - name: Install and configure dependencies
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ || $GITHUB_REF == 'refs/heads/main' ]]; then
+          npm install -g --silent gh-pages@2.0.1
+          git config user.email "ci-build"
+          git config user.name "ci-build"
+        fi
+    - name: Deploy docs to gh-pages branch
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ || $GITHUB_REF == 'refs/heads/main'  ]]; then
+          echo "This is on $CIRCLE_REPOSITORY_URL."
+          if [[ "$CIRCLE_REPOSITORY_URL" == *":facebookresearch/"* ]]; then
+            echo "Deploying"
+            gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/_build/html
+          fi
+        fi
+  docs-links:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/ubuntu_restore_all"
+    - name: Check links
+      run: |
+        . venv/bin/activate
+        cd docs/
+        make linkcheck
+  pypi-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/ubuntu_restore_all"
+    - uses: actions/download-artifact@v4.1.0
+      with:
+        path: nevergrad-build
+    - name: Create .pypirc
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ && $GITHUB_REF != 'refs/heads//.*/' ]]; then
+          echo -e "[pypi]" >> ~/.pypirc
+          echo -e "username = __token__" >> ~/.pypirc
+          echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+        fi
+    - name: Verify tag
+      run: python setup.py verify_circleci_version
+    - name: upload to pypi
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags//(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.post(0|[1-9][0-9]*))?/$ && $GITHUB_REF != 'refs/heads//.*/' ]]; then
+          echo "This is on $CIRCLE_REPOSITORY_URL."
+          if [[ "$CIRCLE_REPOSITORY_URL" == *":facebookresearch/"* ]]; then
+            echo "Deploying"
+            . venv/bin/activate
+            du -h nevergrad-build/dist/*
+            twine check nevergrad-build/dist/nevergrad-*
+            twine upload nevergrad-build/dist/nevergrad-* --verbose
+          fi
+        fi


### PR DESCRIPTION
## Summary

This pull request converts the CircleCI workflows to GitHub actions workflows. [Github Actions Importer](https://github.com/github/gh-actions-importer) was used to convert the workflows initially, then I edited them manually to correct errors in translation.

The `${{ secrets.PYPI_PASSWORD }}`, `${{ github.CIRCLE_REPOSITORY_URL }}`, `${{ secrets.CIRCLE_CI_SSH_KEY }}` and `${{ secrets.CIRCLE_CI_KNOWN_HOSTS }}` settings will need to be set for the tasks to succeed.

**Issues**

```
setuptools.extern.packaging.version.InvalidVersion: Invalid version: 'main'
```

<details>
<summary style="list-style-type: none;">Full Error</summary>
<pre>
Collecting IOHexperimenter>=0.2.8.7 (from nevergrad==1.0.2)
  Downloading IOHexperimenter-0.2.9.2.tar.gz (245 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [27 lines of output]
      Traceback (most recent call last):
        File "/home/runner/work/nevergrad/nevergrad/venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/runner/work/nevergrad/nevergrad/venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/runner/work/nevergrad/nevergrad/venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-soo31i8e/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-soo31i8e/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-soo31i8e/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 487, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-soo31i8e/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 311, in run_setup
          exec(code, locals())
        File "<string>", line 41, in <module>
        File "/tmp/pip-build-env-soo31i8e/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 104, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-soo31i8e/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 146, in setup
          _setup_distribution = dist = klass(attrs)
        File "/tmp/pip-build-env-soo31i8e/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 318, in __init__
          self.metadata.version = self._normalize_version(self.metadata.version)
        File "/tmp/pip-build-env-soo31i8e/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 354, in _normalize_version
          normalized = str(Version(version))
        File "/tmp/pip-build-env-soo31i8e/overlay/lib/python3.9/site-packages/setuptools/_vendor/packaging/version.py", line 200, in __init__
          raise InvalidVersion(f"Invalid version: '{version}'")
      setuptools.extern.packaging.version.InvalidVersion: Invalid version: 'main'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
</pre>
</details>

## How did you test this change?

I tested these changes in a [forked repo](https://github.com/robandpdx-org/nevergrad/actions/runs/9004839319).

https://fburl.com/workplace/f6mz6tmw