### PR TITLE
bayesian_optimization version to 2.0.4 and use Acquisition function instead of utility function

### DIFF
--- a/nevergrad/optimization/optimizerlib.py
+++ b/nevergrad/optimization/optimizerlib.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 import scipy.ndimage as ndimage
 
 try:
-    from bayes_opt import UtilityFunction
+    from bayes_opt import acquisition
     from bayes_opt import BayesianOptimization
 except ModuleNotFoundError:
     pass
@@ -3102,7 +3102,14 @@ try:
         def bo(self) -> BayesianOptimization:
             if self._bo is None:
                 bounds = {self._fake_function.key(i): (0.0, 1.0) for i in range(self.dimension)}
-                self._bo = BayesianOptimization(self._fake_function, bounds, random_state=self._rng)
+                kind = self.utility_kind
+                if kind == "ucb":
+                    util = acquisition.UpperConfidenceBound(kappa=self.utility_kappa,)
+                elif kind == "ei":
+                    util = acquisition.ExpectedImprovement(xi=self.utility_xi,)
+                elif kind == "poi":
+                    util = acquisition.ProbabilityOfImprovement(xi=self.utility_xi,)
+                self._bo = BayesianOptimization(self._fake_function, bounds, util, random_state=self._rng)
                 if self._init_budget is None:
                     assert self.budget is not None
                     init_budget = int(np.sqrt(self.budget))
@@ -3127,11 +3134,10 @@ try:
             return self._bo
 
         def _internal_ask_candidate(self) -> p.Parameter:
-            util = UtilityFunction(kind=self.utility_kind, kappa=self.utility_kappa, xi=self.utility_xi)
             if self.bo._queue:
                 x_probe = next(self.bo._queue)
             else:
-                x_probe = self.bo.suggest(util)  # this is time consuming
+                x_probe = self.bo.suggest()  # this is time consuming
                 x_probe = [x_probe[self._fake_function.key(i)] for i in range(len(x_probe))]
             data = self._normalizer.backward(np.asarray(x_probe))
             candidate = self.parametrization.spawn_child().set_standardized_data(data)

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,6 +1,6 @@
 numpy>=1.24.0
 cma>=2.6.0
-bayesian-optimization==1.4.0
+bayesian-optimization>=2.0.4
 typing_extensions>=3.6.6
 pandas
 directsearch


### PR DESCRIPTION
Upgrade bayesian_optimization version to 2.0.4 and use Acquisition function instead of utility function

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the [**CONTRIBUTING**](https://facebookresearch.github.io/nevergrad/contributing.html) document and completed the CLA (see [**CLA**](https://facebookresearch.github.io/nevergrad/contributing.html#contributor-license-agreement-cla)).
- [ ] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on Nevergrad users Facebook group https://www.facebook.com/groups/nevergradusers/ -->
